### PR TITLE
Making sure the logger not breaking.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "pre-commit": "^1.1.3",
-    "standard": "^8.5.0",
     "pino": "^3.0.1",
+    "pre-commit": "^1.1.3",
+    "proxyquire": "^1.8.0",
+    "standard": "^8.5.0",
     "tap": "^8.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pino-elasticsearch": "./pino-elasticsearch.js"
   },
   "scripts": {
-    "test": "standard && tap test.js"
+    "test": "standard && tap test/*.test.js"
   },
   "pre-commit": "test",
   "keywords": [

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -18,7 +18,6 @@ function pinoElasticSearch (opts) {
       return
     }
     var value = parsed.value
-    console.log(value)
     if (typeof value === 'string') {
       value = {
         data: value,
@@ -74,14 +73,12 @@ function pinoElasticSearch (opts) {
     },
     write: function (body, enc, cb) {
       const obj = {index, type, body}
-      console.log(obj)
       client.index(obj, function (err, data) {
         if (!err) {
           splitter.emit('insert', data, body)
         } else {
           splitter.emit('insertError', err)
         }
-
         // skip error and continue
         cb()
       })

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -19,7 +19,14 @@ function pinoElasticSearch (opts) {
     }
 
     var value = parsed.value
-    value.time = (new Date(value.time)).toISOString()
+    if (typeof value === 'string') {
+      value = {
+        data: value,
+        time: (new Date()).toISOString()
+      };
+    } else {
+      value.time = (new Date(value.time)).toISOString()
+    }
 
     return value
   })

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -17,13 +17,13 @@ function pinoElasticSearch (opts) {
       this.emit('unknown', line, parsed.err)
       return
     }
-
     var value = parsed.value
+    console.log(value)
     if (typeof value === 'string') {
       value = {
         data: value,
         time: (new Date()).toISOString()
-      };
+      }
     } else {
       value.time = (new Date(value.time)).toISOString()
     }
@@ -74,6 +74,7 @@ function pinoElasticSearch (opts) {
     },
     write: function (body, enc, cb) {
       const obj = {index, type, body}
+      console.log(obj)
       client.index(obj, function (err, data) {
         if (!err) {
           splitter.emit('insert', data, body)

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const pino = require('pino')
-const elastic = require('./')
+const elastic = require('../')
 const tap = require('tap')
 const test = require('tap').test
 const elasticsearch = require('elasticsearch')

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const pino = require('pino')
+
+const proxyquire = require('proxyquire')
+
+const test = require('tap').test
+const options = {
+  index: 'pinotest',
+  type: 'log',
+  consistency: 'one',
+  host: 'localhost',
+  port: 9200
+}
+test('make sure log is a valid json', (t) => {
+  t.plan(2)
+  const Client = function (config) {
+    t.equal(config.host, `${options.host}:${options.port}`)
+  }
+  Client.prototype.index = (obj, cb) => {
+    t.ok(obj, true)
+    cb(null, {})
+  }
+  // TODO: test it better
+  // Client.prototype.bulk = (obj, cb) => {
+  //   cb(null, {})
+  // }
+  const elastic = proxyquire('../', {
+    elasticsearch: {
+      Client: Client
+    }
+  })
+  const instance = elastic(options)
+  const log = pino(instance)
+  const prettyLog = JSON.stringify({ service: 'test', msg: 'testing' })
+  log.info(['info'], prettyLog)
+})

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -21,10 +21,6 @@ test('make sure log is a valid json', (t) => {
     t.ok(obj, true)
     cb(null, {})
   }
-  // TODO: test it better
-  // Client.prototype.bulk = (obj, cb) => {
-  //   cb(null, {})
-  // }
   const elastic = proxyquire('../', {
     elasticsearch: {
       Client: Client
@@ -32,6 +28,7 @@ test('make sure log is a valid json', (t) => {
   })
   const instance = elastic(options)
   const log = pino(instance)
-  const prettyLog = JSON.stringify({ service: 'test', msg: 'testing' })
+  const prettyLog = `some logs goes here.
+  another log...`
   log.info(['info'], prettyLog)
 })


### PR DESCRIPTION
When using hapi-pino with `prettyPrint: true` the module will complain that the value.time doesn't exist.
The pr won't fixes the issue but at least the logger is not going to explode.

I might fix in another pr but the issue is when parsing the JSON so we might want to pass a flag that says `Hi that's a pretty JSON` :)

Currently, I'm by passing that by using `prettyPrint: false`