### PR TITLE
Fix basic auth for elasticsearch module

### DIFF
--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -33,6 +33,7 @@ function pinoElasticSearch (opts) {
   const client = new elasticsearch.Client({
     host: opts.host ? opts.host + ':' + opts.port : undefined,
     auth: opts.user ? opts.user + ':' + opts.password : undefined,
+    httpAuth: opts.user ? opts.user + ':' + opts.password : undefined,
     connectionClass: opts['aws-credentials'] ? require('http-aws-es') : undefined,
     awsConfig: opts['aws-credentials'] ? AWS.config.loadFromPath(opts['aws-credentials']) : undefined,
     log: {


### PR DESCRIPTION
elasticsearch looking for httpAuth, not auth key

- [config options for elasticsearch.Client](https://github.com/elastic/elasticsearch-js/blob/8cf09a381db61478082d8f964e5fe5ac96bb7c5e/docs/configuration.asciidoc#config-options)
- https://github.com/elastic/elasticsearch-js/blob/master/src/lib/host.js#L104



=== debug

`curl -i elastic:changeme elastic.example.com` works

running `nodemon -w ./app --inspect=0.0.0.0:9229 | pino-elasticsearch -H elastic.example.com -p 80 --user elastic --password changeme -l trace`

```
Elasticsearch TRACE: 2017-10-15T21:39:34Z
  -> POST http://elastic.example.com:80/_bulk
  {...}

  <- 401
  {
    "error": {
      "root_cause": [
        {
          "type": "security_exception",
          "reason": "missing authentication token for REST request [/_bulk]",
          "header": {
            "WWW-Authenticate": "Basic realm=\"security\" charset=\"UTF-8\""
          }
        }
      ],
      "type": "security_exception",
      "reason": "missing authentication token for REST request [/_bulk]",
      "header": {
        "WWW-Authenticate": "Basic realm=\"security\" charset=\"UTF-8\""
      }
    },
    "status": 401
  }
```