### PR TITLE
Allow for Date in index

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm install pino-elasticsearch -g
   -H  | --host              the IP address of elasticsearch; default: 127.0.0.1
   -p  | --port              the port of elasticsearch; default: 9200
   -i  | --index             the name of the index to use; default: pino
+                            will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -b  | --size              the number of documents for each bulk insert
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -83,7 +83,8 @@ function pinoElasticSearch (opts) {
       })
     },
     write: function (body, enc, cb) {
-      const obj = { index, type, body }
+      var idx = index.replace('%DATE', body.time.substring(0, 10))
+      const obj = { index: idx, type, body }
       client.index(obj, function (err, data) {
         if (!err) {
           splitter.emit('insert', data, body)

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -58,7 +58,12 @@ function pinoElasticSearch (opts) {
       for (var i = 0; i < docs.length; i++) {
         if (i % 2 === 0) {
           // add the header
-          docs[i] = { index: { _index: index, _type: type } }
+          docs[i] = {
+            index: {
+              _type: type,
+              _index: index.replace('%{DATE}', chunks[Math.floor(i / 2)].chunk.time.substring(0, 10))
+            }
+          }
         } else {
           // add the chunk
           docs[i] = chunks[Math.floor(i / 2)].chunk
@@ -83,7 +88,7 @@ function pinoElasticSearch (opts) {
       })
     },
     write: function (body, enc, cb) {
-      var idx = index.replace('%DATE', body.time.substring(0, 10))
+      var idx = index.replace('%{DATE}', body.time.substring(0, 10))
       const obj = { index: idx, type, body }
       client.index(obj, function (err, data) {
         if (!err) {

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -33,6 +33,29 @@ setTimeout(function () {
   process.exit(1)
 }, 60 * 1000).unref()
 
+test('replaces date in index', { timeout }, (t) => {
+  t.plan(3)
+  const index = 'pinotest-%{DATE}'
+
+  const instance = elastic({ index, type, consistency, host, port })
+  const log = pino(instance)
+
+  log.info('hello world')
+
+  instance.on('insert', (obj, body) => {
+    t.ok('data uploaded')
+
+    client.get({
+      index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
+      type,
+      id: obj._id
+    }, (err, response) => {
+      t.error(err)
+      t.deepEqual(response._source, body, 'obj matches')
+    })
+  })
+})
+
 test('store a log line', { timeout }, (t) => {
   t.plan(3)
 

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -33,29 +33,6 @@ setTimeout(function () {
   process.exit(1)
 }, 60 * 1000).unref()
 
-test('replaces date in index', { timeout }, (t) => {
-  t.plan(3)
-  const index = 'pinotest-%{DATE}'
-
-  const instance = elastic({ index, type, consistency, host, port })
-  const log = pino(instance)
-
-  log.info('hello world')
-
-  instance.on('insert', (obj, body) => {
-    t.ok('data uploaded')
-
-    client.get({
-      index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
-      type,
-      id: obj._id
-    }, (err, response) => {
-      t.error(err)
-      t.deepEqual(response._source, body, 'obj matches')
-    })
-  })
-})
-
 test('store a log line', { timeout }, (t) => {
   t.plan(3)
 
@@ -125,6 +102,57 @@ test('store lines in bulk', { timeout }, (t) => {
     setTimeout(function () {
       client.get({
         index,
+        type,
+        id: obj._id
+      }, (err, response) => {
+        t.error(err)
+        t.deepEqual(response._source, body, 'obj matches')
+      })
+    }, refreshInterval)
+  })
+})
+
+test('replaces date in index', { timeout }, (t) => {
+  t.plan(3)
+  const index = 'pinotest-%{DATE}'
+
+  const instance = elastic({ index, type, consistency, host, port })
+  const log = pino(instance)
+
+  log.info('hello world')
+
+  instance.on('insert', (obj, body) => {
+    t.ok('data uploaded')
+
+    client.get({
+      index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
+      type,
+      id: obj._id
+    }, (err, response) => {
+      t.error(err)
+      t.deepEqual(response._source, body, 'obj matches')
+    })
+  })
+})
+
+test('replaces date in index during bulk insert', { timeout }, (t) => {
+  t.plan(15)
+
+  const index = 'pinotest-%{DATE}'
+  const instance = elastic({ index, type, consistency, host, port })
+  const log = pino(instance)
+
+  log.info('hello world')
+  log.info('hello world')
+  log.info('hello world')
+  log.info('hello world')
+  log.info('hello world')
+
+  instance.on('insert', (obj, body) => {
+    t.ok(obj, 'data uploaded')
+    setTimeout(function () {
+      client.get({
+        index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
         type,
         id: obj._id
       }, (err, response) => {

--- a/usage.txt
+++ b/usage.txt
@@ -11,8 +11,8 @@
   -H  | --host              the IP address of elasticsearch; default: 127.0.0.1
   -p  | --port              the port of elasticsearch; default: 9200
   -i  | --index             the name of the index to use; default: pino
+                            will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
-  -c  | --consistency       the consistency of the write; default: one
   -b  | --size              the number of documents for each bulk insert
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
   -c  | --aws-credentials   path to aws_config.json (is using AWS Elasticsearch)


### PR DESCRIPTION
Logstash default option for ElasticSearch is to include the date in the index: https://www.elastic.co/guide/en/logstash/current/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-index

This is quite useful for housekeeping in general, and I'd love to see a similar feature here, I made a quick amendment to support something similar to start a discussion about that, please let me know what you think