### PR TITLE
add support for dynamic index names

### DIFF
--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -47,7 +47,7 @@ function pinoElasticSearch (opts) {
     }
   })
 
-  const index = opts.index || 'pino'
+  const index = typeof opts.index === 'function' ? opts.index : function () { return opts.index || 'pino' }
   const type = opts.type || 'log'
 
   const writable = new Writable({
@@ -58,7 +58,7 @@ function pinoElasticSearch (opts) {
       for (var i = 0; i < docs.length; i++) {
         if (i % 2 === 0) {
           // add the header
-          docs[i] = { index: { _index: index, _type: type } }
+          docs[i] = { index: { _index: index(), _type: type } }
         } else {
           // add the chunk
           docs[i] = chunks[Math.floor(i / 2)].chunk
@@ -83,7 +83,7 @@ function pinoElasticSearch (opts) {
       })
     },
     write: function (body, enc, cb) {
-      const obj = { index, type, body }
+      const obj = { index: index(), type, body }
       client.index(obj, function (err, data) {
         if (!err) {
           splitter.emit('insert', data, body)


### PR DESCRIPTION
This allows for creating time based indices when using the library programmatically:

For example:

```js
// custom-pino-elasticsearch.js
const pinoElasticSearch = require('pino-elasticsearch');
const pump = require('pump');
const pad = require('left-pad');

const padNumber = (num) => pad(num, 2, 0);

pump(
  process.stdin,
  pinoElasticSearch({
    index: () => {
      const now = new Date();
      // format index name as `pino-YYYY-MM-DD`
      return `pino-${now.getFullYear()}-${padNumber(
        now.getUTCMonth() + 1
      )}-${padNumber(now.getUTCDate() + 1)}`;
    },
    host: process.env.ES_LOG_HOST || 'localhost',
    port: process.env.ES_LOG_POST || 9200,
  })
);
```

I had no success with the tests, but the tests were already failing on the CI, so it might be better to get them fixed over there first?