### PR TITLE
Use the new Elasticsearch client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   matrix:
   - ELASTIC_VERSION="5.6.16" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz
   - ELASTIC_VERSION="6.8.0" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.0.tar.gz
-  - ELASTIC_VERSION="7.1.0" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0.tar.gz
+  - ELASTIC_VERSION="7.1.0" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0-linux-x86_64.tar.gz
 
   global:
   - secure: lXGEsFYLLYpo+Snw4brEQQT2cHD3tZYCcgI9XPzWlzQ7gQ1dy8/IN9eeGgGZ4naplT8i3+UtT2gNtmZoRwzjkDUqYBk5jC/UQj0w/3GYbZ5prMb5/YrQsJSyZbUNSiMTHIu+z8A4S7PSHkJuLU3QznkWhMOle8Bx2TY9DmjybBAnQLpGtqeYTXeUoaMX+qZJVOQZh9o63lSVLn30cTPP+tNqk7cbBJrLbj9cl2wsyWPqXSZZwy4p0cu/dx3t8LrFDVnsjJylPtY5bWzj0cdJO/FRP5bU2QWopJ+Nqs9EauCCX9k3qHvWIFT3WInyQ+FGLnFDb6qtg8a21oXDUC2JaX2kw5XEnlbyka0pRKk7nrf9JglAiNMkUjQz9/7FvZoL/AiGdR2w88GEwE4Bno1bKI1MxAPXeAvNQT+TmqrUUyBDtNQsegsqD6dxoJuUBfqb8m2Kli2F1YRFA/zQ98gJSdpO7ho07CH5MGcOzQZ0O3Nz5Hl5OhMhaVB6jvQCnEsPu8OZZUN2XkpypeDQ8blzlSVvwSejWMkRVaf9313HDCTa2m9tgxa8ZOxQTfotgIwAnBCKCYRxNn4ZMIO2aW01d36cnZ2GHXQLjqL/mQC2MbDc4tdXD9zpFvNK7XcfHRtZ4hl/h9d8TJe92vjQxAMgnEzXpZRTfLLmwKI+YY0ImIY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 language: node_js
+
 sudo: false
+
 node_js:
-- '6'
 - '8'
 - '10'
+- '12'
+
 env:
   matrix:
-  - ELASTIC_VERSION="2.3.0" ELASTIC_URL=https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.0/elasticsearch-2.3.0.tar.gz
-  - ELASTIC_VERSION="5.6.12" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.12.tar.gz
-  - ELASTIC_VERSION="6.4.1" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.4.1.tar.gz
+  - ELASTIC_VERSION="5.6.16" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz
+  - ELASTIC_VERSION="6.8.0" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.0.tar.gz
+  - ELASTIC_VERSION="7.1.0" ELASTIC_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0.tar.gz
+
   global:
   - secure: lXGEsFYLLYpo+Snw4brEQQT2cHD3tZYCcgI9XPzWlzQ7gQ1dy8/IN9eeGgGZ4naplT8i3+UtT2gNtmZoRwzjkDUqYBk5jC/UQj0w/3GYbZ5prMb5/YrQsJSyZbUNSiMTHIu+z8A4S7PSHkJuLU3QznkWhMOle8Bx2TY9DmjybBAnQLpGtqeYTXeUoaMX+qZJVOQZh9o63lSVLn30cTPP+tNqk7cbBJrLbj9cl2wsyWPqXSZZwy4p0cu/dx3t8LrFDVnsjJylPtY5bWzj0cdJO/FRP5bU2QWopJ+Nqs9EauCCX9k3qHvWIFT3WInyQ+FGLnFDb6qtg8a21oXDUC2JaX2kw5XEnlbyka0pRKk7nrf9JglAiNMkUjQz9/7FvZoL/AiGdR2w88GEwE4Bno1bKI1MxAPXeAvNQT+TmqrUUyBDtNQsegsqD6dxoJuUBfqb8m2Kli2F1YRFA/zQ98gJSdpO7ho07CH5MGcOzQZ0O3Nz5Hl5OhMhaVB6jvQCnEsPu8OZZUN2XkpypeDQ8blzlSVvwSejWMkRVaf9313HDCTa2m9tgxa8ZOxQTfotgIwAnBCKCYRxNn4ZMIO2aW01d36cnZ2GHXQLjqL/mQC2MbDc4tdXD9zpFvNK7XcfHRtZ4hl/h9d8TJe92vjQxAMgnEzXpZRTfLLmwKI+YY0ImIY=
+
 before_install:
 - echo Installing Elastic $ELASTIC_VERSION from $ELASTIC_URL
 - export JAVA_HOME=/usr/lib/jvm/java-9-oracle
@@ -18,6 +23,7 @@ before_install:
 - curl -s $ELASTIC_URL | tar xz -C /tmp
 - ls /tmp
 - /tmp/elasticsearch-${ELASTIC_VERSION}/bin/elasticsearch &
+
 addons:
   apt:
     packages:

--- a/README.md
+++ b/README.md
@@ -16,28 +16,30 @@ npm install pino-elasticsearch -g
 
   To send pino logs to elasticsearch:
 
-     cat log | pino-elasticsearch --host 192.168.1.42
-
-  If using AWS Elasticsearch:
-    cat log | pino-elasticsearch  --host https://your-url.us-east-1.es.amazonaws.com --port 443 -c ./aws_config.json
+     cat log | pino-elasticsearch --node http://localhost:9200
 
   Flags
   -h  | --help              Display Help
   -v  | --version           display Version
-  -H  | --host              the IP address of elasticsearch; default: 127.0.0.1
-  -p  | --port              the port of elasticsearch; default: 9200
+  -n  | --node              the URL where Elasticsearch is running
   -i  | --index             the name of the index to use; default: pino
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -b  | --size              the number of documents for each bulk insert
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
-  -c  | --aws-credentials   path to aws_config.json (is using AWS Elasticsearch)
+        --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)
+                            (this is needed only if you are using Elasticsearch <= 7)
 
 ```
 
 You can then use [Kibana](https://www.elastic.co/products/kibana) to
 browse and visualize your logs.
 
+### Authentication
+If you need to use basic authentication to connect with the Elasticsearch cluster, pass the credentials in the URL:
+```
+cat log | pino-elasticsearch --node https://user:pwd@localhost:9200
+```
 ## Setup and Testing
 
 Setting up pino-elasticsearch is easy, and you can use the bundled

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ npm install pino-elasticsearch -g
 ```
 
 You can then use [Kibana](https://www.elastic.co/products/kibana) to
-browse and visualize your logs.
+browse and visualize your logs.  
+**Note:** This transport works only with Elasticsearch version ≥ 5.
 
 ### Authentication
 If you need to use basic authentication to connect with the Elasticsearch cluster, pass the credentials in the URL:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pino-elasticsearch": "./pino-elasticsearch.js"
   },
   "scripts": {
-    "test": "standard && tap test/*.test.js"
+    "test": "standard && tap test/*.test.js --no-coverage"
   },
   "pre-commit": "test",
   "keywords": [
@@ -22,21 +22,19 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "pino": "^5.11.1",
+    "pino": "^5.12.6",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.0",
     "standard": "^12.0.1",
-    "tap": "^12.5.1"
+    "tap": "^14.2.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.397.0",
-    "elasticsearch": "^15.3.1",
+    "@elastic/elasticsearch": "^7.1.0",
     "fast-json-parse": "^1.0.3",
-    "http-aws-es": "^6.0.0",
     "minimist": "^1.2.0",
     "pump": "^3.0.0",
-    "readable-stream": "^3.1.1",
-    "split2": "^3.1.0"
+    "readable-stream": "^3.4.0",
+    "split2": "^3.1.1"
   },
   "repository": {
     "type": "git",

--- a/usage.txt
+++ b/usage.txt
@@ -3,17 +3,17 @@
 
   [0mTo send [33mpino[39m logs to elasticsearch:[0m
 
-     [33mcat log | pino-elasticsearch --host 192.168.1.42[39m
+     [33mcat log | pino-elasticsearch --node http://localhost:9200[39m
 
   [36m[1mFlags[22m[39m
   [0m-h  | --help              Display Help
+  -h  | --help              Display Help
   -v  | --version           display Version
-  -H  | --host              the IP address of elasticsearch; default: 127.0.0.1
-  -p  | --port              the port of elasticsearch; default: 9200
+  -n  | --node              the URL where Elasticsearch is running
   -i  | --index             the name of the index to use; default: pino
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -b  | --size              the number of documents for each bulk insert
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
-  -c  | --aws-credentials   path to aws_config.json (is using AWS Elasticsearch)
-
+        --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)
+                            (this is needed only if you are using Elasticsearch <= 7)


### PR DESCRIPTION
As titled.

This pr also removes the aws configuration, since the package has not been updated to support the new client.
It introduces two new cli options:
- `node`: the URL where Elasticsearch is running
- `es-version`: the major version of Elasticsearch you are using (needed only if ≤7)

It removes `host`, `port`, `aws-credentials`.

The minimum version of Node.js required is v8.