### PR TITLE
Ignore lines containing a JSON-parseable boolean

### DIFF
--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -23,7 +23,11 @@ function pinoElasticSearch (opts) {
       this.emit('unknown', line, 'Boolean value ignored')
       return
     }
-    if (typeof value === 'string') {
+    if (value === null) {
+      this.emit('unknown', line, 'Null value ignored')
+      return
+    }
+    if (typeof value !== 'object') {
       value = {
         data: value,
         time: setDateTimeString(value)

--- a/pino-elasticsearch.js
+++ b/pino-elasticsearch.js
@@ -19,6 +19,10 @@ function pinoElasticSearch (opts) {
       return
     }
     var value = parsed.value
+    if (typeof value === 'boolean') {
+      this.emit('unknown', line, 'Boolean value ignored')
+      return
+    }
     if (typeof value === 'string') {
       value = {
         data: value,

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -55,6 +55,19 @@ test('store a log line', { timeout }, (t) => {
   })
 })
 
+test('Ignores a boolean line even though it is JSON-parseable', { timeout }, (t) => {
+  t.plan(2)
+
+  const instance = elastic({ index, type, consistency, host, port })
+
+  instance.on('unknown', (obj, body) => {
+    t.equal(obj, 'true', 'Object is parsed')
+    t.equal(body, 'Boolean value ignored', 'Message is sent')
+  })
+
+  instance.write('true\n')
+})
+
 test('store an deeply nested log line', { timeout }, (t) => {
   t.plan(4)
 

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -62,10 +62,35 @@ test('Ignores a boolean line even though it is JSON-parseable', { timeout }, (t)
 
   instance.on('unknown', (obj, body) => {
     t.equal(obj, 'true', 'Object is parsed')
-    t.equal(body, 'Boolean value ignored', 'Message is sent')
+    t.equal(body, 'Boolean value ignored', 'Message is emitted')
   })
 
   instance.write('true\n')
+})
+
+test('Ignores "null" being parsed as json', { timeout }, (t) => {
+  t.plan(2)
+
+  const instance = elastic({ index, type, consistency, host, port })
+
+  instance.on('unknown', (obj, body) => {
+    t.equal(obj, 'null', 'Object is parsed')
+    t.equal(body, 'Null value ignored', 'Message is emitted')
+  })
+
+  instance.write('null\n')
+})
+
+test('Can process number being parsed as json', { timeout }, (t) => {
+  t.plan(0)
+
+  const instance = elastic({ index, type, consistency, host, port })
+
+  instance.on('unknown', (obj, body) => {
+    t.error(obj, body)
+  })
+
+  instance.write('12\n')
 })
 
 test('store an deeply nested log line', { timeout }, (t) => {


### PR DESCRIPTION
Following-up with https://github.com/pinojs/pino-elasticsearch/issues/27