### PR TITLE
Fix #36

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         npm install
         docker-compose -f docker-compose-v7.yml up -d
+        sleep 30
         npm test
       env:
         CI: true


### PR DESCRIPTION
We should wait for Elasticserch to be ready before start running the test.
This can be designed better by implementing a [`waitCluster`](https://github.com/elastic/elasticsearch-js/blob/7fef37cf902ec6b2825ea929eed48cf3734613d0/test/integration/index.js#L82-L93) function.