### PR TITLE
Split cli and lib files

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+'use strict'
+
+const minimist = require('minimist')
+const pump = require('pump')
+const fs = require('fs')
+const path = require('path')
+const pinoElasticSearch = require('./lib')
+
+function start (opts) {
+  if (opts.help) {
+    console.log(fs.readFileSync(path.join(__dirname, './usage.txt'), 'utf8'))
+    return
+  }
+
+  if (opts.version) {
+    console.log('pino-elasticsearch', require('./package.json').version)
+    return
+  }
+
+  pump(process.stdin, pinoElasticSearch(opts))
+}
+
+if (require.main === module) {
+  start(minimist(process.argv.slice(2), {
+    alias: {
+      version: 'v',
+      help: 'h',
+      node: 'n',
+      index: 'i',
+      'bulk-size': 'b',
+      'trace-level': 'l'
+    },
+    default: {
+      node: 'http://localhost:9200'
+    }
+  }))
+}

--- a/cli.js
+++ b/cli.js
@@ -21,18 +21,16 @@ function start (opts) {
   pump(process.stdin, pinoElasticSearch(opts))
 }
 
-if (require.main === module) {
-  start(minimist(process.argv.slice(2), {
-    alias: {
-      version: 'v',
-      help: 'h',
-      node: 'n',
-      index: 'i',
-      'bulk-size': 'b',
-      'trace-level': 'l'
-    },
-    default: {
-      node: 'http://localhost:9200'
-    }
-  }))
-}
+start(minimist(process.argv.slice(2), {
+  alias: {
+    version: 'v',
+    help: 'h',
+    node: 'n',
+    index: 'i',
+    'bulk-size': 'b',
+    'trace-level': 'l'
+  },
+  default: {
+    node: 'http://localhost:9200'
+  }
+}))

--- a/lib.js
+++ b/lib.js
@@ -1,14 +1,8 @@
-#! /usr/bin/env node
-'use strict'
-
-const minimist = require('minimist')
+const pump = require('pump')
+const split = require('split2')
 const Writable = require('readable-stream').Writable
 const { Client } = require('@elastic/elasticsearch')
 const Parse = require('fast-json-parse')
-const split = require('split2')
-const pump = require('pump')
-const fs = require('fs')
-const path = require('path')
 const toEcs = require('pino-to-ecs')
 
 function pinoElasticSearch (opts) {
@@ -127,33 +121,3 @@ function pinoElasticSearch (opts) {
 }
 
 module.exports = pinoElasticSearch
-
-function start (opts) {
-  if (opts.help) {
-    console.log(fs.readFileSync(path.join(__dirname, './usage.txt'), 'utf8'))
-    return
-  }
-
-  if (opts.version) {
-    console.log('pino-elasticsearch', require('./package.json').version)
-    return
-  }
-
-  pump(process.stdin, pinoElasticSearch(opts))
-}
-
-if (require.main === module) {
-  start(minimist(process.argv.slice(2), {
-    alias: {
-      version: 'v',
-      help: 'h',
-      node: 'n',
-      index: 'i',
-      'bulk-size': 'b',
-      'trace-level': 'l'
-    },
-    default: {
-      node: 'http://localhost:9200'
-    }
-  }))
-}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "pino-elasticsearch",
   "version": "4.2.0",
   "description": "Load pino logs into ElasticSearch",
-  "main": "pino-elasticsearch",
+  "main": "./lib.js",
   "bin": {
-    "pino-elasticsearch": "./pino-elasticsearch.js"
+    "pino-elasticsearch": "./cli.js"
   },
   "scripts": {
     "test": "standard && tap test/*.test.js --no-esm -j 1 --no-coverage --timeout 120"


### PR DESCRIPTION
Importing this library into a project with a bundler (webpack) needs to use shebang-loader. Also, Isolating library code improves readability.