### PR TITLE
Added option for passing through the ssl options

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -44,7 +44,7 @@ function pinoElasticSearch (opts) {
     return value
   })
 
-  const client = new Client({ node: opts.node })
+  const client = new Client({ node: opts.node, ssl: opts.ssl });
 
   const esVersion = Number(opts['es-version']) || 7
   const useEcs = !!opts['ecs']

--- a/lib.js
+++ b/lib.js
@@ -44,7 +44,7 @@ function pinoElasticSearch (opts) {
     return value
   })
 
-  const client = new Client({ node: opts.node, ssl: opts.ssl });
+  const client = new Client({ node: opts.node, ssl: opts.ssl })
 
   const esVersion = Number(opts['es-version']) || 7
   const useEcs = !!opts['ecs']


### PR DESCRIPTION
Now you can pass SSL options to pino-elasticsearch and he will pass to the `Client`. #44