### PR TITLE
CLI Support for dynamic index names

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,7 @@ start(minimist(process.argv.slice(2), {
     help: 'h',
     node: 'n',
     index: 'i',
+    'require-index': 'r',
     'bulk-size': 'b',
     'trace-level': 'l'
   },

--- a/lib.js
+++ b/lib.js
@@ -52,7 +52,7 @@ function pinoElasticSearch (opts) {
 
   const esVersion = Number(opts['es-version']) || 7
   const useEcs = !!opts.ecs
-  const index = opts.index || 'pino'
+  const index = opts['require-index'] ? require((opts['require-index'] || '').replace(/^\./, process.cwd)) : (opts.index || 'pino')
   const buildIndexName = typeof index === 'function' ? index : null
   const type = opts.type || 'log'
 

--- a/usage.txt
+++ b/usage.txt
@@ -12,6 +12,9 @@
   -n  | --node              the URL where Elasticsearch is running
   -i  | --index             the name of the index to use; default: pino
                             will replace %{DATE} with the YYYY-MM-DD date
+  -r  | --require-index     A path resolving to a JavaScript module that exports a function which
+			    can be used to dynamically build an index name.  Analogous to node's
+			    -r switch.  See `Dynamic index`
   -t  | --type              the name of the type to use; default: log
   -b  | --size              the number of documents for each bulk insert
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).


### PR DESCRIPTION
This patch introduces an equivalent dynamic index name support in the CLI
version of pino-elastic search via a `-r` CLI parameter.

-r is analogous to node's require flag in that it allows users of the
commandline to specify a module require path that contains a factory
function which produces an index in exactly the same fashion as what's
already there in the _usage as a module_ section of the documentation.

Usage:

Given I have a `factory.js` file in the current directory with the following
contents:

```js
module.exports = function (date) {
  // return an index name
}
```

And I use pino-elasticsearch on the commandline according to the following format:

```
cat log | pino-elasticsearch -r ./factory
```

Then I will have the index generated as per the function in the `./factory` module, in exactly the same fashion as the usage as a module functionality. 