### PR TITLE
Use the client bulk indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ npm install pino-elasticsearch -g
   -i  | --index             the name of the index to use; default: pino
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
-  -b  | --size              the number of documents for each bulk insert
+  -f  | --flush-bytes       the number of bytes for each bulk insert; default: 1000
+  -b  | --bulk-size         the number of documents for each bulk insert [DEPERCATED]
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
       | --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)
                             (this is needed only if you are using Elasticsearch <= 7)
@@ -43,7 +44,7 @@ const streamToElastic = pinoElastic({
   consistency: 'one',
   node: 'http://localhost:9200',
   'es-version': 7,
-  'bulk-size': 200
+  'flush-bytes': 1000
 })
 
 const logger = pino({ level: 'info' }, streamToElastic)
@@ -66,7 +67,7 @@ const streamToElastic = pinoElastic({
   consistency: 'one',
   node: 'http://localhost:9200',
   'es-version': 7,
-  'bulk-size': 200
+  'flush-bytes': 1000
 })
 
 const logger = pino({ level: 'info',  ...ecsFormat  }, streamToElastic)

--- a/cli.js
+++ b/cli.js
@@ -28,6 +28,7 @@ start(minimist(process.argv.slice(2), {
     node: 'n',
     index: 'i',
     'bulk-size': 'b',
+    'flush-bytes': 'f',
     'trace-level': 'l'
   },
   default: {

--- a/lib.js
+++ b/lib.js
@@ -2,9 +2,7 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const pump = require('pump')
 const split = require('split2')
-const Writable = require('readable-stream').Writable
 const { Client } = require('@elastic/elasticsearch')
 const Parse = require('fast-json-parse')
 
@@ -30,7 +28,9 @@ function pinoElasticSearch (opts) {
         time: setDateTimeString(value)
       }
     } else {
-      value.time = setDateTimeString(value)
+      if (value['@timestamp'] === undefined) {
+        value.time = setDateTimeString(value)
+      }
     }
 
     function setDateTimeString (value) {
@@ -53,75 +53,36 @@ function pinoElasticSearch (opts) {
   const index = opts.index || 'pino'
   const buildIndexName = typeof index === 'function' ? index : null
   const type = opts.type || 'log'
-
-  const writable = new Writable({
-    objectMode: true,
-    highWaterMark: opts['bulk-size'] || 500,
-    writev: function (chunks, cb) {
-      const docs = new Array(chunks.length * 2)
-      for (var i = 0; i < docs.length; i++) {
-        if (i % 2 === 0) {
-          // add the header
-          docs[i] = {
-            index: {
-              // from Elasticsearch v8 and above, types will be removed
-              // while in Elasticsearch v7 types are deprecated
-              _type: esVersion >= 7 ? undefined : type,
-              _index: getIndexName(chunks[Math.floor(i / 2)].chunk.time)
-            }
-          }
-        } else {
-          // add the chunk
-          docs[i] = chunks[Math.floor(i / 2)].chunk
+  const b = client.helpers.bulk({
+    datasource: splitter,
+    flushBytes: opts['flush-bytes'],
+    onDocument (doc) {
+      return {
+        index: {
+          _index: getIndexName(doc.time || doc['@timestamp']),
+          _type: esVersion >= 7 ? undefined : type
         }
       }
-      client.bulk({
-        body: docs
-      }, function (err, result) {
-        if (!err) {
-          const items = result.body.items
-          for (var i = 0; i < items.length; i++) {
-            // depending on the Elasticsearch version, the bulk response might
-            // contain fields 'create' or 'index' (> ES 5.x)
-            const create = items[i].index || items[i].create
-            splitter.emit('insert', create, docs[i * 2 + 1])
-          }
-        } else {
-          splitter.emit('insertError', err)
-        }
-        // skip error and continue
-        cb()
-      })
     },
-    write: function (body, enc, cb) {
-      var idx = getIndexName(body.time)
-      // from Elasticsearch v8 and above, types will be removed
-      // while in Elasticsearch v7 types are deprecated
-      const obj = {
-        index: idx,
-        type: esVersion >= 7 ? undefined : type,
-        body: body
-      }
-      client.index(obj, function (err, data) {
-        if (!err) {
-          splitter.emit('insert', data.body, obj.body)
-        } else {
-          splitter.emit('insertError', err)
-        }
-        // skip error and continue
-        cb()
-      })
+    onDrop (doc) {
+      const error = new Error('Dropped document')
+      error.onDocument = doc
+      splitter.emit('insertError', error)
     }
   })
 
-  function getIndexName (time) {
+  b.then(
+    (stats) => splitter.emit('insert', stats),
+    (err) => splitter.emit('error', err)
+  )
+
+  function getIndexName (time = Date.now()) {
     if (buildIndexName) {
       return buildIndexName(time)
     }
     return index.replace('%{DATE}', time.substring(0, 10))
   }
 
-  pump(splitter, writable)
   return splitter
 }
 

--- a/lib.js
+++ b/lib.js
@@ -56,6 +56,7 @@ function pinoElasticSearch (opts) {
   const b = client.helpers.bulk({
     datasource: splitter,
     flushBytes: opts['flush-bytes'],
+    refreshOnCompletion: getIndexName(),
     onDocument (doc) {
       return {
         index: {
@@ -66,7 +67,7 @@ function pinoElasticSearch (opts) {
     },
     onDrop (doc) {
       const error = new Error('Dropped document')
-      error.onDocument = doc
+      error.document = doc
       splitter.emit('insertError', error)
     }
   })
@@ -76,7 +77,7 @@ function pinoElasticSearch (opts) {
     (err) => splitter.emit('error', err)
   )
 
-  function getIndexName (time = Date.now()) {
+  function getIndexName (time = new Date().toISOString()) {
     if (buildIndexName) {
       return buildIndexName(time)
     }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "pino": "^6.2.1",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
-    "standard": "^14.0.0",
-    "tap": "^14.10.6"
+    "standard": "^14.3.4",
+    "tap": "^14.10.7"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.6.0",
+    "@elastic/elasticsearch": "^7.7.1",
     "fast-json-parse": "^1.0.3",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
     "split2": "^3.1.1"

--- a/usage.txt
+++ b/usage.txt
@@ -13,7 +13,8 @@
   -i  | --index             the name of the index to use; default: pino
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
-  -b  | --size              the number of documents for each bulk insert
+  -f  | --flush-bytes       the number of bytes for each bulk insert; default: 1000
+  -b  | --bulk-size         the number of documents for each bulk insert [DEPERCATED]
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
         --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)
                             (this is needed only if you are using Elasticsearch <= 7)


### PR DESCRIPTION
The latest version of the client offers a bulk indexer, which automatically handles the retries and lets you pick the flush bytes threshold.
You can find the bulk indexer documentation [here](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-helpers.html).

The mechanics are slightly different, you can only know if a document has failed, so the `insert` event, which as far as I know it is only used for testing, will not be emitted more than once.
The test now will fail because I didn't update the monkey patch yet, but I wanted to have an early feedback before continuing, especially around the stream handling.

This pr makes useless the `bulk-size` option, as the client's bulk indexer needs a value in bytes. This because you can't know in advance the size of a log, and could risk sending a big number of very big logs or very few small logs. The ability to set the flush size in bytes solves this problem.

A nice side effect of using the bulk indexer is that we gain the automatic retry of failed documents for free ;)