### PR TITLE
`flush-interval` setting added

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npm install pino-elasticsearch -g
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -f  | --flush-bytes       the number of bytes for each bulk insert; default: 1000
+  -t  | --flush-interval    time that the helper will wait before flushing; default: 30000
   -b  | --bulk-size         the number of documents for each bulk insert [DEPERCATED]
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
       | --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)

--- a/cli.js
+++ b/cli.js
@@ -44,6 +44,7 @@ start(minimist(process.argv.slice(2), {
     index: 'i',
     'bulk-size': 'b',
     'flush-bytes': 'f',
+    'flush-interval': 'fi',
     'trace-level': 'l',
     username: 'u',
     password: 'p',

--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ start(minimist(process.argv.slice(2), {
     index: 'i',
     'bulk-size': 'b',
     'flush-bytes': 'f',
-    'flush-interval': 'fi',
+    'flush-interval': 't',
     'trace-level': 'l',
     username: 'u',
     password: 'p',

--- a/lib.js
+++ b/lib.js
@@ -61,6 +61,7 @@ function pinoElasticSearch (opts) {
   const b = client.helpers.bulk({
     datasource: splitter,
     flushBytes: opts['flush-bytes'] || 1000,
+    flushInterval: opts['flush-interval'] || 30000,
     refreshOnCompletion: getIndexName(),
     onDocument (doc) {
       return {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -199,3 +199,24 @@ test('apikey is passed through auth param properly to client', (t) => {
   })
   elastic(opts)
 })
+
+test('make sure `flush-interval` is passed to bulk request', (t) => {
+  t.plan(2)
+  const Client = function (config) {
+    t.equal(config.node, options.node)
+  }
+  Client.prototype.helpers = {
+    async bulk (opts) {
+      t.equal(opts.flushInterval, 12345)
+      t.end()
+    }
+  }
+  const elastic = proxyquire('../', {
+    '@elastic/elasticsearch': { Client }
+  })
+
+  options['flush-interval'] = 12345
+  const instance = elastic(options)
+  const log = pino(instance)
+  log.info(['info'], 'abc')
+})

--- a/usage.txt
+++ b/usage.txt
@@ -14,7 +14,7 @@
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -f  | --flush-bytes       the number of bytes for each bulk insert; default: 1000
-  -fi | --flush-interval    time that the helper will wait before flushing; default: 30000
+  -t  | --flush-interval    time that the helper will wait before flushing; default: 30000
   -b  | --bulk-size         the number of documents for each bulk insert [DEPERCATED]
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
         --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)

--- a/usage.txt
+++ b/usage.txt
@@ -14,6 +14,7 @@
                             will replace %{DATE} with the YYYY-MM-DD date
   -t  | --type              the name of the type to use; default: log
   -f  | --flush-bytes       the number of bytes for each bulk insert; default: 1000
+  -fi | --flush-interval    time that the helper will wait before flushing; default: 30000
   -b  | --bulk-size         the number of documents for each bulk insert [DEPERCATED]
   -l  | --trace-level       trace level for the elasticsearch client, default 'error' (info, debug, trace).
         --es-version        specify the major version number of Elasticsearch (eg: 5, 6, 7)


### PR DESCRIPTION
closes #57 

* `30000` as a default option, same as in the client.
* `t` is the new flag for the CLI.