### PR TITLE
Don't reject private network https connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install pino-elasticsearch -g
                             (can only be used in tandem with the 'username' flag)
   -k  | --api-key           Api key for authentication instead of username/password combination
   -c  | --cloud             Id of the elastic cloud node to connect to
+  --rejectUnauthorized      Reject any connection which is not authorized with the list of supplied CAs; default: true
 
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -33,6 +33,10 @@ function start (opts) {
     opts.cloud = { id: opts.cloud }
   }
 
+  if (opts.rejectUnauthorized) {
+    opts.rejectUnauthorized = opts.rejectUnauthorized !== 'false'
+  }
+
   pump(process.stdin, pinoElasticSearch(opts))
 }
 

--- a/lib.js
+++ b/lib.js
@@ -54,7 +54,7 @@ function pinoElasticSearch (opts) {
     return value
   })
 
-  const client = new Client({ node: opts.node, auth: opts.auth, cloud: opts.cloud })
+  const client = new Client({ node: opts.node, auth: opts.auth, cloud: opts.cloud, ssl: { rejectUnauthorized: false } })
 
   const esVersion = Number(opts['es-version']) || 7
   const index = opts.index || 'pino'

--- a/lib.js
+++ b/lib.js
@@ -54,7 +54,12 @@ function pinoElasticSearch (opts) {
     return value
   })
 
-  const client = new Client({ node: opts.node, auth: opts.auth, cloud: opts.cloud, ssl: { rejectUnauthorized: false } })
+  const client = new Client({
+    node: opts.node,
+    auth: opts.auth,
+    cloud: opts.cloud,
+    ssl: { rejectUnauthorized: opts.rejectUnauthorized }
+  })
 
   const esVersion = Number(opts['es-version']) || 7
   const index = opts.index || 'pino'

--- a/usage.txt
+++ b/usage.txt
@@ -25,3 +25,4 @@
                             (can only be used in tandem with the 'username' flag)
   -k  | --api-key           Api key for authentication instead of username/password combination
   -c  | --cloud             Id of the elastic cloud node to connect to
+  --rejectUnauthorized      Reject any connection which is not authorized with the list of supplied CAs; default: true


### PR DESCRIPTION
Kibana and ElasticSearch require https to be set up, even for private networks, but all connections got rejected.