### PR TITLE
feat: enable to read config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ npm install pino-elasticsearch -g
                             (can only be used in tandem with the 'username' flag)
   -k  | --api-key           Api key for authentication instead of username/password combination
   -c  | --cloud             Id of the elastic cloud node to connect to
+  -r  | --read-config       the name of config file
   --rejectUnauthorized      Reject any connection which is not authorized with the list of supplied CAs; default: true
 
 ```

--- a/cli.js
+++ b/cli.js
@@ -66,14 +66,14 @@ if (flags['read-config']) {
   if (flags['read-config'].match(/.*\.json$/) !== null) {
     const config = JSON.parse(fs.readFileSync(path.join(__dirname, flags['read-config']), 'utf-8'))
     allowedProps.forEach(key => {
-	  if(config[key]) flags[key] = config[key]
+      if (config[key]) { flags[key] = config[key] }
     })
   }
 
   if (flags['read-config'].match(/.*\.js$/) !== null) {
     const config = require(path.join(__dirname, flags['read-config']))
     allowedProps.forEach(key => {
-	  if(config[key]) flags[key] = config[key]
+      if (config[key]) { flags[key] = config[key] }
     })
   }
 }

--- a/cli.js
+++ b/cli.js
@@ -64,14 +64,14 @@ const allowedProps = ['node', 'index', 'bulk-size', 'flush-btyes', 'flush-interv
 
 if (flags['read-config']) {
   if (flags['read-config'].match(/.*\.json$/) !== null) {
-    const config = JSON.parse(fs.readFileSync(path.join(__dirname, flags['read-config']), 'utf-8'))
+    const config = JSON.parse(fs.readFileSync(path.join(process.cwd(), flags['read-config']), 'utf-8'))
     allowedProps.forEach(key => {
       if (config[key]) { flags[key] = config[key] }
     })
   }
 
   if (flags['read-config'].match(/.*\.js$/) !== null) {
-    const config = require(path.join(__dirname, flags['read-config']))
+    const config = require(path.join(process.cwd(), flags['read-config']))
     allowedProps.forEach(key => {
       if (config[key]) { flags[key] = config[key] }
     })

--- a/cli.js
+++ b/cli.js
@@ -36,11 +36,10 @@ function start (opts) {
   if (opts.rejectUnauthorized) {
     opts.rejectUnauthorized = opts.rejectUnauthorized !== 'false'
   }
-
   pump(process.stdin, pinoElasticSearch(opts))
 }
 
-start(minimist(process.argv.slice(2), {
+const flags = minimist(process.argv.slice(2), {
   alias: {
     version: 'v',
     help: 'h',
@@ -53,9 +52,29 @@ start(minimist(process.argv.slice(2), {
     username: 'u',
     password: 'p',
     'api-key': 'k',
-    cloud: 'c'
+    cloud: 'c',
+    'read-config': 'r'
   },
   default: {
     node: 'http://localhost:9200'
   }
-}))
+})
+
+const allowedProps = ['node', 'index', 'bulk-size', 'flush-btyes', 'flush-interval', 'trace-level', 'username', 'password', 'api-key', 'cloud', 'es-version', 'rejectUnauthorized']
+
+if (flags['read-config']) {
+  if (flags['read-config'].match(/.*\.json$/) !== null) {
+    const config = JSON.parse(fs.readFileSync(path.join(__dirname, flags['read-config']), 'utf-8'))
+    allowedProps.forEach(key => {
+      config[key] ? flags[key] = config[key] : null
+    })
+  }
+
+  if (flags['read-config'].match(/.*\.js$/) !== null) {
+    const config = require(path.join(__dirname, flags['read-config']))
+    allowedProps.forEach(key => {
+      config[key] ? flags[key] = config[key] : null
+    })
+  }
+}
+start(flags)

--- a/cli.js
+++ b/cli.js
@@ -66,14 +66,14 @@ if (flags['read-config']) {
   if (flags['read-config'].match(/.*\.json$/) !== null) {
     const config = JSON.parse(fs.readFileSync(path.join(__dirname, flags['read-config']), 'utf-8'))
     allowedProps.forEach(key => {
-      config[key] ? flags[key] = config[key] : null
+	  if(config[key]) flags[key] = config[key]
     })
   }
 
   if (flags['read-config'].match(/.*\.js$/) !== null) {
     const config = require(path.join(__dirname, flags['read-config']))
     allowedProps.forEach(key => {
-      config[key] ? flags[key] = config[key] : null
+	  if(config[key]) flags[key] = config[key]
     })
   }
 }

--- a/usage.txt
+++ b/usage.txt
@@ -25,4 +25,5 @@
                             (can only be used in tandem with the 'username' flag)
   -k  | --api-key           Api key for authentication instead of username/password combination
   -c  | --cloud             Id of the elastic cloud node to connect to
+  -r | --read-config       the config file to read
   --rejectUnauthorized      Reject any connection which is not authorized with the list of supplied CAs; default: true


### PR DESCRIPTION
enable CLI to read config file

Usage:

`node ./index.js | tee -a ./pino_log/http.log | jq -c 'del(.req.headers) | del(.http.response.headers) | del(.redact)' | pino-elasticsearch -r config.json`