### PR TITLE
[feature] Custom Connection Support for ES Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,31 @@ return pino(pinoOptions, pinoMultiStream([
 
 You can learn more about `pino-multi-stream` here: https://github.com/pinojs/pino-multi-stream.
 
+### Custom Connection
+
+If you want to use a custom Connection class for the Elasticsearch client, you can pass it as an option when using as a module. See the Elasticsearch client docs for [Connection](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/advanced-config.html#_connection).
+
+```js
+const pino = require('pino')
+const pinoElastic = require('pino-elasticsearch')
+
+const Connection = <custom Connection>
+
+const streamToElastic = pinoElastic({
+  index: 'an-index',
+  consistency: 'one',
+  node: 'http://localhost:9200',
+  'es-version': 7,
+  'flush-bytes': 1000,
+  Connection
+})
+
+const logger = pino({ level: 'info' }, streamToElastic)
+
+logger.info('hello world')
+// ...
+```
+
 ### Troubleshooting
 
 Assuming your Elasticsearch instance is running and accessible, there are a couple of common problems that will cause indices or events (log entries) to not be created in Elasticsearch when using this library.  Developers can get feedback on these problems by listening for events returned by the stream handler.

--- a/lib.js
+++ b/lib.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const split = require('split2')
-const { Client, Connection, Transport } = require('@elastic/elasticsearch')
+const { Client, Connection } = require('@elastic/elasticsearch')
 
 function pinoElasticSearch (opts) {
   if (opts['bulk-size']) {
@@ -59,8 +59,7 @@ function pinoElasticSearch (opts) {
     auth: opts.auth,
     cloud: opts.cloud,
     ssl: { rejectUnauthorized: opts.rejectUnauthorized },
-    Connection: opts.Connection || Connection,
-    Transport: opts.Transport || Transport
+    Connection: opts.Connection || Connection
   })
 
   const esVersion = Number(opts['es-version']) || 7

--- a/lib.js
+++ b/lib.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const split = require('split2')
-const { Client } = require('@elastic/elasticsearch')
+const { Client, Connection, Transport } = require('@elastic/elasticsearch')
 
 function pinoElasticSearch (opts) {
   if (opts['bulk-size']) {
@@ -58,7 +58,9 @@ function pinoElasticSearch (opts) {
     node: opts.node,
     auth: opts.auth,
     cloud: opts.cloud,
-    ssl: { rejectUnauthorized: opts.rejectUnauthorized }
+    ssl: { rejectUnauthorized: opts.rejectUnauthorized },
+    Connection: opts.Connection || Connection,
+    Transport: opts.Transport || Transport
   })
 
   const esVersion = Number(opts['es-version']) || 7


### PR DESCRIPTION
Allow custom Connection object for the ElasticSearch Client.

Reason: Some providers such as AWS need requests to be signed using custom logic. The client allows a custom Connection to handle these things. This keeps  the logic from being needed inside of the pino-elasticsearch package itself, as there are many Connection packages/custom solutions already in use, ready to plug into it.

Example usage:
```
const Conenction = <my custom ES Connection class>

const streamToElastic = pinoElastic({
  index: 'test-index',
  consistency: 'one',
  node: process.env.ELASTICSEARCH_URL,
  'es-version': 7,
  'flush-bytes': 1000,
  Connection
})
```

Behavior when not included is to use the default one from the ElasticSearch Client.

Example script using modified version: https://github.com/nicksmider/pino-aws-es-signV4-test/blob/main/index.js

I believe this would address #15 as well