### PR TITLE
Datastream support using op_type create config

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,22 @@ const streamToElastic = pinoElastic({
 
 The function **must** be sync, doesn't throw and return a string.
 
+#### Datastreams
+
+Indexing to datastreams requires the `op_type` to be set to `create`:
+```js
+const pino = require('pino')
+const pinoElastic = require('pino-elasticsearch')
+
+const streamToElastic = pinoElastic({
+  index: "type-dataset-namespace",
+  consistency: 'one',
+  node: 'http://localhost:9200',
+  op_type: 'create'
+})
+// ...
+```
+
 #### Error handling
 ```js
 const pino = require('pino')

--- a/docker-compose-v7-es-only-datastreams.yml
+++ b/docker-compose-v7-es-only-datastreams.yml
@@ -1,0 +1,9 @@
+---
+version: '3.6'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0
+    environment:
+      - discovery.type=single-node
+    container_name: elasticsearch
+    ports: ['9200:9200']

--- a/lib.js
+++ b/lib.js
@@ -66,16 +66,23 @@ function pinoElasticSearch (opts) {
   const index = opts.index || 'pino'
   const buildIndexName = typeof index === 'function' ? index : null
   const type = esVersion >= 7 ? undefined : (opts.type || 'log')
+  const opType = esVersion >= 7 ? opts.op_type : undefined
   const b = client.helpers.bulk({
     datasource: splitter,
     flushBytes: opts['flush-bytes'] || 1000,
     flushInterval: opts['flush-interval'] || 30000,
     refreshOnCompletion: getIndexName(),
     onDocument (doc) {
+      const date = doc.time || doc['@timestamp']
+      if (opType === 'create') {
+        doc['@timestamp'] = date
+      }
+
       return {
         index: {
-          _index: getIndexName(doc.time || doc['@timestamp']),
-          _type: type
+          _index: getIndexName(date),
+          _type: type,
+          op_type: opType
         }
       }
     },

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -230,15 +230,15 @@ test('make sure `flush-interval` is passed to bulk request', (t) => {
 })
 
 test('make sure `op_type` is passed to bulk onDocument request', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const Client = function (config) {}
 
   Client.prototype.helpers = {
     async bulk (opts) {
       const result = opts.onDocument({})
-      t.equal(result.index?._index, 'logs-pino-test', '_index should be correctly set to `logs-pino-test`')
-      t.equal(result.index?.op_type, 'create', '`op_type` should be set to `create`')
+      t.equal(result.index._index, 'logs-pino-test', '_index should be correctly set to `logs-pino-test`')
+      t.equal(result.index.op_type, 'create', '`op_type` should be set to `create`')
       t.end()
     }
   }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14,6 +14,14 @@ const options = {
   node: 'http://localhost:9200'
 }
 
+const dsOptions = {
+  index: 'logs-pino-test',
+  type: 'log',
+  consistency: 'one',
+  node: 'http://localhost:9200',
+  op_type: 'create'
+}
+
 test('make sure date format is valid', (t) => {
   t.type(fix.datetime.object, 'string')
   t.equal(fix.datetime.object, fix.datetime.string)
@@ -217,6 +225,52 @@ test('make sure `flush-interval` is passed to bulk request', (t) => {
 
   options['flush-interval'] = 12345
   const instance = elastic(options)
+  const log = pino(instance)
+  log.info(['info'], 'abc')
+})
+
+test('make sure `op_type` is passed to bulk onDocument request', (t) => {
+  t.plan(3)
+
+  const Client = function (config) {}
+
+  Client.prototype.helpers = {
+    async bulk (opts) {
+      const result = opts.onDocument({})
+      t.equal(result.index?._index, 'logs-pino-test', '_index should be correctly set to `logs-pino-test`')
+      t.equal(result.index?.op_type, 'create', '`op_type` should be set to `create`')
+      t.end()
+    }
+  }
+  const elastic = proxyquire('../', {
+    '@elastic/elasticsearch': { Client }
+  })
+
+  const instance = elastic(dsOptions)
+  const log = pino(instance)
+  log.info(['info'], 'abc')
+})
+
+test('make sure `@timestamp` is correctly set when `op_type` is `create`', (t) => {
+  t.plan(1)
+
+  const document = {
+    time: '2021-09-01T01:01:01.038Z'
+  }
+  const Client = function (config) {}
+
+  Client.prototype.helpers = {
+    async bulk (opts) {
+      opts.onDocument(document)
+      t.equal(document['@timestamp'], '2021-09-01T01:01:01.038Z', 'Document @timestamp does not equal the provided timestamp')
+      t.end()
+    }
+  }
+  const elastic = proxyquire('../', {
+    '@elastic/elasticsearch': { Client }
+  })
+
+  const instance = elastic(dsOptions)
   const log = pino(instance)
   log.info(['info'], 'abc')
 })


### PR DESCRIPTION
This PR allows users to specify the datastream name as the index and set the op_type to create.
AFAIK this doesn't break any existing functionality.