### PR TITLE
fix bug: opts.rejectUnauthorized for SSL option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,13 +45,48 @@ function start (opts) {
     console.error('Elasticsearch server error:', error)
   })
 
-  if (opts.rejectUnauthorized) {
-    opts.rejectUnauthorized = opts.rejectUnauthorized !== 'false'
-  }
   pump(process.stdin, stream)
 }
 
-const flags = minimist(process.argv.slice(2), {
+function startCli (flags) {
+  const allowedProps = [
+    'node',
+    'index',
+    'flush-bytes',
+    'flush-interval',
+    'trace-level',
+    'username',
+    'password',
+    'api-key',
+    'cloud',
+    'es-version',
+    'rejectUnauthorized'
+  ]
+
+  if (flags['read-config']) {
+    if (flags['read-config'].match(/.*\.json$/) !== null) {
+      const config = JSON.parse(fs.readFileSync(path.join(process.cwd(), flags['read-config']), 'utf-8'))
+      allowedProps.forEach(key => {
+        if (config[key] !== undefined) {
+          flags[key] = config[key]
+        }
+      })
+    }
+    if (flags['read-config'].match(/.*\.js$/) !== null) {
+      const config = require(path.join(process.cwd(), flags['read-config']))
+      allowedProps.forEach(key => {
+        if (config[key] !== undefined) {
+          flags[key] = config[key]
+        }
+      })
+    }
+  }
+
+  start(flags)
+}
+
+if (require.main === module) {
+  startCli(minimist(process.argv.slice(2), {
   alias: {
     version: 'v',
     help: 'h',
@@ -69,23 +104,7 @@ const flags = minimist(process.argv.slice(2), {
   default: {
     node: 'http://localhost:9200'
   }
-})
-
-const allowedProps = ['node', 'index', 'flush-bytes', 'flush-interval', 'trace-level', 'username', 'password', 'api-key', 'cloud', 'es-version', 'rejectUnauthorized']
-
-if (flags['read-config']) {
-  if (flags['read-config'].match(/.*\.json$/) !== null) {
-    const config = JSON.parse(fs.readFileSync(path.join(process.cwd(), flags['read-config']), 'utf-8'))
-    allowedProps.forEach(key => {
-      if (config[key]) { flags[key] = config[key] }
-    })
+  }))
   }
 
-  if (flags['read-config'].match(/.*\.js$/) !== null) {
-    const config = require(path.join(process.cwd(), flags['read-config']))
-    allowedProps.forEach(key => {
-      if (config[key]) { flags[key] = config[key] }
-    })
-  }
-}
-start(flags)
+module.exports = startCli

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,107 @@
+'use strict'
+const test = require('tap').test
+const proxyquire = require('proxyquire')
+
+test('CLI: arg node should passed to client constructor', async (t) => {
+  const cli = proxyquire('../cli.js', {
+    pump: () => { },
+    './lib.js': (opts) => {
+      t.same(opts, { node: 'https://custom-node-url:9999' })
+      return {
+        on: () => { }
+      }
+    }
+  })
+
+  cli({ node: 'https://custom-node-url:9999' })
+})
+
+test('CLI: arg rejectUnauthorized, if set to \'true\', should passed as true (bool) to client constructor', async (t) => {
+  const cli = proxyquire('../cli.js', {
+    pump: () => { },
+    './lib.js': (opts) => {
+      t.same(opts, {
+        node: 'https://custom-node-url:9999',
+        rejectUnauthorized: true
+      })
+      return {
+        on: () => { }
+      }
+    }
+  })
+
+  cli({
+    node: 'https://custom-node-url:9999',
+    rejectUnauthorized: 'true'
+  })
+})
+
+test('CLI: arg rejectUnauthorized, if set to \'false\', should passed as false (bool) to client constructor', async (t) => {
+  const cli = proxyquire('../cli.js', {
+    pump: () => { },
+    './lib.js': (opts) => {
+      t.same(opts, {
+        node: 'https://custom-node-url:9999',
+        rejectUnauthorized: false
+      })
+      return {
+        on: () => { }
+      }
+    }
+  })
+
+  cli({
+    node: 'https://custom-node-url:9999',
+    rejectUnauthorized: 'false'
+  })
+})
+
+test('CLI: arg rejectUnauthorized, if set to anything instead of true or false, should passed as true (bool) to client constructor', async (t) => {
+  const cli = proxyquire('../cli.js', {
+    pump: () => { },
+    './lib.js': (opts) => {
+      t.same(opts, {
+        node: 'https://custom-node-url:9999',
+        rejectUnauthorized: true
+      })
+      return {
+        on: () => { }
+      }
+    }
+  })
+
+  cli({
+    node: 'https://custom-node-url:9999',
+    rejectUnauthorized: 'anything'
+  })
+})
+
+test('CLI: if arg.read-config is set, should read the config file and passed the value (only allowed values)', async (t) => {
+  const cli = proxyquire('../cli.js', {
+    pump: () => { },
+    './lib.js': (opts) => {
+      t.same(opts, {
+        index: 'custom-index',
+        node: 'https://localhost:9200',
+        rejectUnauthorized: false,
+        auth: {
+          username: 'elastic',
+          password: 'pass'
+        },
+        // some keys are redundant, it is intended as it is.
+        // (see function start() in cli.js)
+        'read-config': 'test/exampleConfig.js',
+        username: 'elastic',
+        password: 'pass'
+      })
+      return {
+        on: () => { }
+      }
+    }
+  })
+
+  cli({
+    node: 'https://custom-node-url:9999',
+    'read-config': 'test/exampleConfig.js'
+  })
+})

--- a/test/exampleConfig.js
+++ b/test/exampleConfig.js
@@ -1,0 +1,7 @@
+module.exports = {
+  index: 'custom-index',
+  node: 'https://localhost:9200',
+  rejectUnauthorized: false,
+  username: 'elastic',
+  password: 'pass'
+}


### PR DESCRIPTION
### Using cli args
the options passed to the client does not include ```rejectUnauthorized``` because the value is added after the client is create.
So, I moved the code right before the client creation.

### Using configuration file
the check for allowed keys will skip the key if the value is false, so the options will not include the key. To fix this, the code should only skip if the value is undefined. 

```
allowedProps.forEach(key => {
      if (config[key] !== undefined) { flags[key] = config[key] }
    })
```