### PR TITLE
fix(types): use type export matching module.exports

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,7 +1,7 @@
 import type { Transform } from 'stream'
 import type { ClientOptions } from '@elastic/elasticsearch'
 
-export default pinoElasticsearch
+export = pinoElasticsearch
 
 declare function pinoElasticsearch(options?: Options): DestinationStream
 


### PR DESCRIPTION
The type in lib.d.ts uses export default where the lib.js file uses module.exports =. This will cause TypeScript under the node16 and nodenext module resolution mode to think an extra .default property access is required, but that will fail at runtime. This type should use export = instead of export default.

Further reading about the specifics of the issue can be found here: [https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md)

This pull request aims to fix import issues for Typescript projects using --moduleResolution node16 or nodenext