### PR TITLE
fix(elastic): rename ssl options to tls

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -123,7 +123,7 @@ function pinoElasticSearch (opts = {}) {
     node: opts.node,
     auth: opts.auth,
     cloud: opts.cloud,
-    ssl: { rejectUnauthorized: opts.rejectUnauthorized, ...opts.tls }
+    tls: { rejectUnauthorized: opts.rejectUnauthorized, ...opts.tls }
   }
 
   if (opts.caFingerprint) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -456,7 +456,7 @@ test('make sure deprecated `rejectUnauthorized` is passed to client constructor'
   const rejectUnauthorized = true
 
   const Client = function (config) {
-    t.equal(config.ssl.rejectUnauthorized, rejectUnauthorized)
+    t.equal(config.tls.rejectUnauthorized, rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }
@@ -477,7 +477,7 @@ test('make sure `tls.rejectUnauthorized` is passed to client constructor', (t) =
   const tls = { rejectUnauthorized: true }
 
   const Client = function (config) {
-    t.equal(config.ssl.rejectUnauthorized, tls.rejectUnauthorized)
+    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }
@@ -499,7 +499,7 @@ test('make sure `tls.rejectUnauthorized` overrides deprecated `rejectUnauthorize
   const tls = { rejectUnauthorized: false }
 
   const Client = function (config) {
-    t.equal(config.ssl.rejectUnauthorized, tls.rejectUnauthorized)
+    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }


### PR DESCRIPTION
#180 In version 8 renamed the ssl option to tls. 
This commit adjusts the code to reflect this change, ensuring compatibility with Elasticsearch 8.

[Rename ssl option to tls](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/changelog-client.html#_rename_ssl_option_to_tls)
[Link to documentation](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-connecting.html#auth-tls)
