### PR TITLE
Updated dependencies to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pino-elasticsearch": "./cli.js"
   },
   "scripts": {
-    "test": "standard && tsd && tap test/*.test.js -j 1 --no-coverage --timeout 120"
+    "test": "standard && tsd && tap test/*.test.js -j 1 --disable-coverage --timeout 120"
   },
   "pre-commit": "test",
   "keywords": [
@@ -23,20 +23,20 @@
   "author": "Matteo Collina <hello@matteocollina.com>",
   "license": "MIT",
   "devDependencies": {
-    "@elastic/ecs-pino-format": "^1.1.1",
-    "@types/node": "^20.5.0",
-    "pino": "^8.4.0",
+    "@elastic/ecs-pino-format": "^1.5.0",
+    "@types/node": "^20.12.7",
+    "pino": "^9.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
-    "standard": "^17.0.0",
-    "tap": "^16.0.0",
+    "standard": "^17.1.0",
+    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^8.0.0",
-    "minimist": "^1.2.5",
+    "@elastic/elasticsearch": "^8.13.1",
+    "minimist": "^1.2.8",
     "pump": "^3.0.0",
-    "split2": "^4.0.0"
+    "split2": "^4.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR addresses this issue https://github.com/pinojs/pino-elasticsearch/issues/186 for updating ping to v9