### PR TITLE
Update ecsFormat examples to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ const streamToElastic = pinoElastic({
   flushBytes: 1000
 })
 
-const logger = pino({ level: 'info',  ...ecsFormat  }, streamToElastic)
+const logger = pino({ level: 'info',  ...ecsFormat()  }, streamToElastic)
 
 logger.info('hello world')
 // ...


### PR DESCRIPTION
In the readme, both `const logger = pino({ level: 'info',  ...ecsFormat }, streamToElastic)` and `const logger = pino({ level: 'info',  ...ecsFormat()  }, streamToElastic)` are used.  I believe you need to invoke `ecsFormat()` so I made the fix