### PR TITLE
Modernize code and drop old Node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22, 24]
     steps:
       - name: Check out repo
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pino-elasticsearch&nbsp;&nbsp;[![Build Status](https://github.com/pinojs/pino-elasticsearch/workflows/CI/badge.svg)](https://github.com/pinojs/pino-elasticsearch/actions)&nbsp;[![Coverage Status](https://coveralls.io/repos/github/pinojs/pino-elasticsearch/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino-elasticsearch?branch=master)
+# pino-elasticsearch&nbsp;&nbsp;[![Build Status](https://github.com/pinojs/pino-elasticsearch/workflows/CI/badge.svg)](https://github.com/pinojs/pino-elasticsearch/actions)
 
 Load [pino](https://github.com/pinojs/pino) logs into
 [Elasticsearch](https://www.elastic.co/products/elasticsearch).

--- a/lib.js
+++ b/lib.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const split = require('split2')
-const { Client } = require('@elastic/elasticsearch')
+const { Client: DefaultClient } = require('@elastic/elasticsearch')
 
 function initializeBulkHandler (opts, client, splitter) {
   const esVersion = Number(opts.esVersion || opts['es-version']) || 7
@@ -58,7 +58,7 @@ function initializeBulkHandler (opts, client, splitter) {
   }
 }
 
-function pinoElasticSearch (opts = {}) {
+function pinoElasticSearch (opts = {}, { Client = DefaultClient } = {}) {
   if (opts['flush-bytes']) {
     process.emitWarning('The "flush-bytes" option has been deprecated, use "flushBytes" instead')
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,12 +1,14 @@
 'use strict'
-const test = require('tap').test
+
+const test = require('node:test')
 const proxyquire = require('proxyquire')
 
 test('CLI: arg node should passed to client constructor', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, { node: 'https://custom-node-url:9999' })
+      t.assert.deepEqual(opts, { node: 'https://custom-node-url:9999' })
       return {
         on: () => { }
       }
@@ -17,10 +19,11 @@ test('CLI: arg node should passed to client constructor', async (t) => {
 })
 
 test('CLI: arg rejectUnauthorized, if set to \'true\', should passed as true (bool) to client constructor', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: true
       })
@@ -37,10 +40,11 @@ test('CLI: arg rejectUnauthorized, if set to \'true\', should passed as true (bo
 })
 
 test('CLI: arg rejectUnauthorized, if set to \'false\', should passed as false (bool) to client constructor', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: false
       })
@@ -57,10 +61,11 @@ test('CLI: arg rejectUnauthorized, if set to \'false\', should passed as false (
 })
 
 test('CLI: arg rejectUnauthorized, if set to anything instead of true or false, should passed as true (bool) to client constructor', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: true
       })
@@ -77,10 +82,11 @@ test('CLI: arg rejectUnauthorized, if set to anything instead of true or false, 
 })
 
 test('CLI: if arg.read-config is set, should read the config file and passed the value (only allowed values)', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         index: 'custom-index',
         node: 'https://127.0.0.1:9200',
         rejectUnauthorized: false,
@@ -107,10 +113,11 @@ test('CLI: if arg.read-config is set, should read the config file and passed the
 })
 
 test('CLI: arg opType should be passed to client constructor', async (t) => {
+  t.plan(1)
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         opType: 'create'
       })

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,10 +1,13 @@
 'use strict'
 
+const test = require('node:test')
+const assert = require('node:assert')
 const pino = require('pino')
 const proxyquire = require('proxyquire')
-const test = require('tap').test
-const fix = require('./fixtures')
 const EcsFormat = require('@elastic/ecs-pino-format')
+
+const elastic = require('../')
+const fix = require('./fixtures')
 
 const matchISOString = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
 const options = {
@@ -19,497 +22,497 @@ const dsOptions = {
 }
 
 test('make sure date format is valid', (t) => {
-  t.type(fix.datetime.object, 'string')
-  t.equal(fix.datetime.object, fix.datetime.string)
-  t.end()
+  assert.equal(typeof fix.datetime.object, 'string')
+  assert.equal(fix.datetime.object, fix.datetime.string)
 })
 
-test('make sure log is a valid json', (t) => {
+test('make sure log is a valid json', (t, end) => {
   t.plan(4)
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    process._rawDebug('!!! config')
+    t.assert.equal(config.node, options.node)
   }
   Client.prototype.diagnostic = { on: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
-        t.ok(chunk, true)
-        t.type(chunk.time, 'string')
-        t.match(chunk.time, matchISOString)
+        process._rawDebug('!!! bulk.loop')
+        t.assert.equal(typeof chunk, 'object')
+        t.assert.equal(typeof chunk.time, 'string')
+        t.assert.match(chunk.time, matchISOString)
       }
+      process._rawDebug('!!! bulk.end')
+      end()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(options)
+  const instance = elastic(options, { Client })
   const log = pino(instance)
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
 })
 
-test('date can be a number', (t) => {
-  t.plan(1)
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  const threeDaysInMillis = 3 * 24 * 60 * 60 * 1000
-  const time = new Date(Date.now() - threeDaysInMillis)
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        t.equal(chunk.time, time.toISOString())
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(options)
-  const log = pino(instance)
-  log.info({
-    time: time.getTime()
-  })
-})
-
-test('Uses the type parameter only with ES < 7 / 1', (t) => {
-  t.plan(2)
-
-  const Client = function (config) {
-    t.equal(config.node, options.node)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        const action = opts.onDocument(chunk)
-        t.equal(action.index._type, 'log')
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 6 }))
-  const log = pino(instance)
-  const prettyLog = `some logs goes here.
-  another log...`
-  log.info(['info'], prettyLog)
-})
-
-test('Uses the type parameter only with ES < 7 / 1, even with the deprecated `esVersion` option', (t) => {
-  t.plan(2)
-
-  const Client = function (config) {
-    t.equal(config.node, options.node)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        const action = opts.onDocument(chunk)
-        t.equal(action.index._type, 'log')
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 6 }))
-  const log = pino(instance)
-  const prettyLog = `some logs goes here.
-  another log...`
-  log.info(['info'], prettyLog)
-})
-
-test('Uses the type parameter only with ES < 7 / 2', (t) => {
-  t.plan(2)
-
-  const Client = function (config) {
-    t.equal(config.node, options.node)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        const action = opts.onDocument(chunk)
-        t.equal(action.index._type, undefined)
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 7 }))
-  const log = pino(instance)
-  const prettyLog = `some logs goes here.
-  another log...`
-  log.info(['info'], prettyLog)
-})
-
-test('Uses the type parameter only with ES < 7 / 2, even with the deprecate `esVersion` option', (t) => {
-  t.plan(2)
-  const Client = function (config) {
-    t.equal(config.node, options.node)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        const action = opts.onDocument(chunk)
-        t.equal(action.index._type, undefined)
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 7 }))
-  const log = pino(instance)
-  const prettyLog = `some logs goes here.
-  another log...`
-  log.info(['info'], prettyLog)
-})
-
-test('ecs format', (t) => {
-  t.plan(5)
-  const Client = function (config) {
-    t.equal(config.node, options.node)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      for await (const chunk of opts.datasource) {
-        t.ok(chunk, true)
-        t.type(chunk['@timestamp'], 'string')
-        t.equal(chunk.message, prettyLog)
-        t.match(chunk['@timestamp'], matchISOString)
-      }
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { ecs: true }))
-  const ecsFormat = EcsFormat()
-  const log = pino({ ...ecsFormat }, instance)
-  const prettyLog = `some logs goes here.
-  another log...`
-  log.info(['info'], prettyLog)
-})
-
-test('auth and cloud parameters are properly passed to client', (t) => {
-  const opts = {
-    ...options,
-    auth: {
-      username: 'user',
-      password: 'pass'
-    },
-    cloud: {
-      id: 'name:aHR0cHM6Ly9leGFtcGxlLmNvbQ=='
-    }
-  }
-
-  t.plan(3)
-  const Client = function (config) {
-    t.equal(config.node, opts.node)
-    t.equal(config.auth, opts.auth)
-    t.equal(config.cloud, opts.cloud)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {}
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  elastic(opts)
-})
-
-test('apiKey is passed through auth param properly to client', (t) => {
-  const opts = {
-    ...options,
-    auth: {
-      apiKey: 'aHR0cHM6Ly9leGFtcGxlLmNvbQ'
-    }
-  }
-
-  t.plan(2)
-  const Client = function (config) {
-    t.equal(config.node, opts.node)
-    t.equal(config.auth, opts.auth)
-  }
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {}
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  elastic(opts)
-})
-
-test('make sure `flushInterval` is passed to bulk request', (t) => {
-  t.plan(1)
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      t.equal(opts.flushInterval, 12345)
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  options.flushInterval = 12345
-  const instance = elastic(options)
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure deprecated `flushInterval` is passed to bulk request', (t) => {
-  t.plan(1)
-
-  const flushInterval = 12345
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      t.equal(opts.flushInterval, flushInterval)
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, flushInterval })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure `flushBytes` is passed to bulk request', (t) => {
-  t.plan(1)
-
-  const flushBytes = true
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      t.equal(opts.flushBytes, flushBytes)
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, flushBytes })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure deprecated `flush-bytes` is passed to bulk request', (t) => {
-  t.plan(1)
-
-  const flushBytes = true
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      t.equal(opts.flushBytes, flushBytes)
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, 'flush-bytes': flushBytes })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure `opType` is passed to bulk onDocument request', (t) => {
-  t.plan(2)
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      const result = opts.onDocument({})
-      t.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
-      t.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
-      t.end()
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic(dsOptions)
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure deprecated `op_type` is passed to bulk onDocument request', (t) => {
-  t.plan(2)
-
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      const result = opts.onDocument({})
-      t.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
-      t.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
-      t.end()
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const { opType, ...rest } = dsOptions
-
-  const instance = elastic({ ...rest, op_type: opType })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure `@timestamp` is correctly set when `opType` is `create`', (t) => {
-  t.plan(1)
-
-  const document = {
-    time: '2021-09-01T01:01:01.038Z'
-  }
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    async bulk (opts) {
-      opts.onDocument(document)
-      t.equal(document['@timestamp'], '2021-09-01T01:01:01.038Z', 'Document @timestamp does not equal the provided timestamp')
-      t.end()
-    }
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic(dsOptions)
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('resurrect client connection pool when datasource split is destroyed', (t) => {
-  let isResurrected = false
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
-
-  Client.prototype.helpers = {
-    bulk: async function (opts) {
-      if (!isResurrected) {
-        opts.datasource.destroy()
-      }
-    }
-  }
-
-  Client.prototype.connectionPool = {
-    resurrect: function () {
-      isResurrected = true
-      t.end()
-    }
-  }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options })
-  const log = pino(instance)
-
-  const prettyLog = 'Example of a log'
-  log.info(['info'], prettyLog)
-})
-
-test('make sure deprecated `rejectUnauthorized` is passed to client constructor', (t) => {
-  t.plan(1)
-
-  const rejectUnauthorized = true
-
-  const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, rejectUnauthorized)
-  }
-
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, rejectUnauthorized })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure `tls.rejectUnauthorized` is passed to client constructor', (t) => {
-  t.plan(1)
-
-  const tls = { rejectUnauthorized: true }
-
-  const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
-  }
-
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, tls })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
-
-test('make sure `tls.rejectUnauthorized` overrides deprecated `rejectUnauthorized`', (t) => {
-  t.plan(1)
-
-  const rejectUnauthorized = true
-  const tls = { rejectUnauthorized: false }
-
-  const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
-  }
-
-  Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
-
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, rejectUnauthorized, tls })
-  const log = pino(instance)
-  log.info(['info'], 'abc')
-})
+// test('date can be a number', (t) => {
+//   t.plan(1)
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   const threeDaysInMillis = 3 * 24 * 60 * 60 * 1000
+//   const time = new Date(Date.now() - threeDaysInMillis)
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         t.assert.equal(chunk.time, time.toISOString())
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(options)
+//   const log = pino(instance)
+//   log.info({
+//     time: time.getTime()
+//   })
+// })
+//
+// test('Uses the type parameter only with ES < 7 / 1', (t) => {
+//   t.plan(2)
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.node, options.node)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         const action = opts.onDocument(chunk)
+//         t.assert.equal(action.index._type, 'log')
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(Object.assign(options, { esVersion: 6 }))
+//   const log = pino(instance)
+//   const prettyLog = `some logs goes here.
+//   another log...`
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('Uses the type parameter only with ES < 7 / 1, even with the deprecated `esVersion` option', (t) => {
+//   t.plan(2)
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.node, options.node)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         const action = opts.onDocument(chunk)
+//         t.assert.equal(action.index._type, 'log')
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(Object.assign(options, { esVersion: 6 }))
+//   const log = pino(instance)
+//   const prettyLog = `some logs goes here.
+//   another log...`
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('Uses the type parameter only with ES < 7 / 2', (t) => {
+//   t.plan(2)
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.node, options.node)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         const action = opts.onDocument(chunk)
+//         t.assert.equal(action.index._type, undefined)
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(Object.assign(options, { esVersion: 7 }))
+//   const log = pino(instance)
+//   const prettyLog = `some logs goes here.
+//   another log...`
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('Uses the type parameter only with ES < 7 / 2, even with the deprecate `esVersion` option', (t) => {
+//   t.plan(2)
+//   const Client = function (config) {
+//     t.assert.equal(config.node, options.node)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         const action = opts.onDocument(chunk)
+//         t.assert.equal(action.index._type, undefined)
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(Object.assign(options, { esVersion: 7 }))
+//   const log = pino(instance)
+//   const prettyLog = `some logs goes here.
+//   another log...`
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('ecs format', (t) => {
+//   t.plan(5)
+//   const Client = function (config) {
+//     t.assert.equal(config.node, options.node)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       for await (const chunk of opts.datasource) {
+//         t.assert.equal(chunk, true)
+//         t.assert.equal(typeof chunk['@timestamp'], 'string')
+//         t.assert.equal(chunk.message, prettyLog)
+//         t.match(chunk['@timestamp'], matchISOString)
+//       }
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   const instance = elastic(Object.assign(options, { ecs: true }))
+//   const ecsFormat = EcsFormat()
+//   const log = pino({ ...ecsFormat }, instance)
+//   const prettyLog = `some logs goes here.
+//   another log...`
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('auth and cloud parameters are properly passed to client', (t) => {
+//   const opts = {
+//     ...options,
+//     auth: {
+//       username: 'user',
+//       password: 'pass'
+//     },
+//     cloud: {
+//       id: 'name:aHR0cHM6Ly9leGFtcGxlLmNvbQ=='
+//     }
+//   }
+//
+//   t.plan(3)
+//   const Client = function (config) {
+//     t.assert.equal(config.node, opts.node)
+//     t.assert.equal(config.auth, opts.auth)
+//     t.assert.equal(config.cloud, opts.cloud)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = {
+//     async bulk (opts) {}
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   elastic(opts)
+// })
+//
+// test('apiKey is passed through auth param properly to client', (t) => {
+//   const opts = {
+//     ...options,
+//     auth: {
+//       apiKey: 'aHR0cHM6Ly9leGFtcGxlLmNvbQ'
+//     }
+//   }
+//
+//   t.plan(2)
+//   const Client = function (config) {
+//     t.assert.equal(config.node, opts.node)
+//     t.assert.equal(config.auth, opts.auth)
+//   }
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = {
+//     async bulk (opts) {}
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//   elastic(opts)
+// })
+//
+// test('make sure `flushInterval` is passed to bulk request', (t) => {
+//   t.plan(1)
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       t.assert.equal(opts.flushInterval, 12345)
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   options.flushInterval = 12345
+//   const instance = elastic(options)
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure deprecated `flushInterval` is passed to bulk request', (t) => {
+//   t.plan(1)
+//
+//   const flushInterval = 12345
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       t.assert.equal(opts.flushInterval, flushInterval)
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, flushInterval })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure `flushBytes` is passed to bulk request', (t) => {
+//   t.plan(1)
+//
+//   const flushBytes = true
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       t.assert.equal(opts.flushBytes, flushBytes)
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, flushBytes })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure deprecated `flush-bytes` is passed to bulk request', (t) => {
+//   t.plan(1)
+//
+//   const flushBytes = true
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       t.assert.equal(opts.flushBytes, flushBytes)
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, 'flush-bytes': flushBytes })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure `opType` is passed to bulk onDocument request', (t) => {
+//   t.plan(2)
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       const result = opts.onDocument({})
+//       t.assert.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
+//       t.assert.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
+//       t.end()
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic(dsOptions)
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure deprecated `op_type` is passed to bulk onDocument request', (t) => {
+//   t.plan(2)
+//
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       const result = opts.onDocument({})
+//       t.assert.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
+//       t.assert.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
+//       t.end()
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const { opType, ...rest } = dsOptions
+//
+//   const instance = elastic({ ...rest, op_type: opType })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure `@timestamp` is correctly set when `opType` is `create`', (t) => {
+//   t.plan(1)
+//
+//   const document = {
+//     time: '2021-09-01T01:01:01.038Z'
+//   }
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     async bulk (opts) {
+//       opts.onDocument(document)
+//       t.assert.equal(document['@timestamp'], '2021-09-01T01:01:01.038Z', 'Document @timestamp does not equal the provided timestamp')
+//       t.end()
+//     }
+//   }
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic(dsOptions)
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('resurrect client connection pool when datasource split is destroyed', (t) => {
+//   let isResurrected = false
+//   const Client = function (config) {}
+//   Client.prototype.diagnostic = { on: () => {} }
+//
+//   Client.prototype.helpers = {
+//     bulk: async function (opts) {
+//       if (!isResurrected) {
+//         opts.datasource.destroy()
+//       }
+//     }
+//   }
+//
+//   Client.prototype.connectionPool = {
+//     resurrect: function () {
+//       isResurrected = true
+//       t.end()
+//     }
+//   }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options })
+//   const log = pino(instance)
+//
+//   const prettyLog = 'Example of a log'
+//   log.info(['info'], prettyLog)
+// })
+//
+// test('make sure deprecated `rejectUnauthorized` is passed to client constructor', (t) => {
+//   t.plan(1)
+//
+//   const rejectUnauthorized = true
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.tls.rejectUnauthorized, rejectUnauthorized)
+//   }
+//
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = { async bulk () {} }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, rejectUnauthorized })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure `tls.rejectUnauthorized` is passed to client constructor', (t) => {
+//   t.plan(1)
+//
+//   const tls = { rejectUnauthorized: true }
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
+//   }
+//
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = { async bulk () {} }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, tls })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })
+//
+// test('make sure `tls.rejectUnauthorized` overrides deprecated `rejectUnauthorized`', (t) => {
+//   t.plan(1)
+//
+//   const rejectUnauthorized = true
+//   const tls = { rejectUnauthorized: false }
+//
+//   const Client = function (config) {
+//     t.assert.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
+//   }
+//
+//   Client.prototype.diagnostic = { on: () => {} }
+//   Client.prototype.helpers = { async bulk () {} }
+//
+//   const elastic = proxyquire('../', {
+//     '@elastic/elasticsearch': { Client }
+//   })
+//
+//   const instance = elastic({ ...options, rejectUnauthorized, tls })
+//   const log = pino(instance)
+//   log.info(['info'], 'abc')
+// })


### PR DESCRIPTION
This is blocked because I cannot get `test/unit.test.js` to work. There isn't any script in `package.json` that indicates how to run these tests locally. It's all set up to run with GHA's container environment. I tried using `docker compose -f docker-compose-v8.yml up` to start a target server, but the first real test that attempts to read data never completes its iteration of the data source.

Anyone that cares about this module is welcome to pick up the work, or start anew. I have no vested interest in this module, so I'm moving on.