### PR TITLE
refactor!: modernize codebase and drop Node.js 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22, 24]
     steps:
       - name: Check out repo
         uses: actions/checkout@v6
@@ -58,9 +58,9 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
 
       - name: Runs Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@562b8b6ae4677da97273ff6bc4d630ce96ecbaa5
+        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65
         with:
-          stack-version: 8.3.3
+          stack-version: 8.19.1
           security-enabled: false
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pino-elasticsearch&nbsp;&nbsp;[![Build Status](https://github.com/pinojs/pino-elasticsearch/workflows/CI/badge.svg)](https://github.com/pinojs/pino-elasticsearch/actions)&nbsp;[![Coverage Status](https://coveralls.io/repos/github/pinojs/pino-elasticsearch/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino-elasticsearch?branch=master)
 
 Load [pino](https://github.com/pinojs/pino) logs into
-[Elasticsearch](https://www.elastic.co/products/elasticsearch).
+[Elasticsearch](https://www.elastic.co/elasticsearch).
 
 ## Install
 
@@ -91,7 +91,7 @@ Please note: The `options` must be serializable. For example if you use a functi
 
 ### Custom Connection
 
-If you want to use a custom Connection class for the Elasticsearch client, you can pass it as an option when using as a module. See the Elasticsearch client docs for [Connection](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/advanced-config.html#_connection).
+If you want to use a custom Connection class for the Elasticsearch client, you can pass it as an option when using as a module. See the Elasticsearch client docs for [Connection](https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/advanced-config#_connection).
 
 ```js
 const pino = require('pino')
@@ -187,7 +187,7 @@ streamToElastic.on(
 
 ### ECS support
 
-If you want to use [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html), you should install [`@elastic/ecs-pino-format`](https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-pino-format), as the `ecs` option of this module has been removed.
+If you want to use [Elastic Common Schema](https://www.elastic.co/docs/reference/ecs), you should install [`@elastic/ecs-pino-format`](https://github.com/elastic/ecs-logging-nodejs/blob/main/packages/ecs-pino-format), as the `ecs` option of this module has been removed.
 
 ```js
 const pino = require('pino')
@@ -207,7 +207,7 @@ logger.info('hello world')
 // ...
 ```
 
-You can then use [Kibana](https://www.elastic.co/products/kibana) to
+You can then use [Kibana](https://www.elastic.co/kibana) to
 browse and visualize your logs.  
 **Note:** This transport works only with Elasticsearch version ≥ 5.
 
@@ -280,10 +280,10 @@ cat log | pino-elasticsearch --node https://user:pwd@localhost:9200
 ```
 
 Alternatively you can supply a combination of `username` and `password` OR `api-key`:
-```
+```sh
 cat log | pino-elasticsearch --node https://localhost:9200 -u user -p pwd
 ```
-```
+```sh
 cat log | pino-elasticsearch --node https://localhost:9200 --api-key=base64EncodedKey
 ```
 
@@ -292,7 +292,8 @@ Elastic cloud option `cloud` is also supported:
 cat log | pino-elasticsearch --cloud=name:bG9jYWxob3N0JGFiY2QkZWZnaA== --api-key=base64EncodedKey
 ```
 
-Note: When using the cli, if you pass username/password AND an apiKey the apiKey will take precedence over the username/password combination.
+> [!NOTE]
+> When using the cli, if you pass username/password AND an apiKey the apiKey will take precedence over the username/password combination.
 
 You can also include the `auth` field in your configuration like so:
 ```js
@@ -328,14 +329,14 @@ const streamToElastic = pinoElastic({
 })
 ```
 
-For a full list of authentication options when using elastic, check out the [authentication configuration docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/auth-reference.html)
+For a full list of authentication options when using elastic, check out the [authentication configuration docs](https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/connecting#authentication)
 
 ## Setup and Testing
 
 Setting up pino-elasticsearch is easy, and you can use the bundled
 `docker-compose.yml` file to bring up both
-[Elasticsearch](https://www.elastic.co/products/elasticsearch) and
-[Kibana](https://www.elastic.co/products/kibana).
+[Elasticsearch](https://www.elastic.co/elasticsearch) and
+[Kibana](https://www.elastic.co/kibana).
 
 You will need [docker](https://www.docker.com/) and
 [docker-compose](https://docs.docker.com/compose/), then in this project
@@ -347,7 +348,7 @@ installed globally.
 
 ## Acknowledgements
 
-This project was kindly sponsored by [nearForm](http://nearform.com).
+This project was kindly sponsored by [nearForm](https://nearform.com/).
 
 ## License
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { defineConfig } = require('eslint/config')
+const neostandard = require('neostandard')
+
+module.exports = defineConfig([
+  neostandard({
+    ts: true,
+  }),
+])

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -3,7 +3,7 @@ import type { ClientOptions } from '@elastic/elasticsearch'
 
 export default pinoElasticsearch
 
-declare function pinoElasticsearch(options?: Options): DestinationStream
+declare function pinoElasticsearch (options?: Options): DestinationStream
 
 export type DestinationStream = Transform & {
   /**

--- a/lib.js
+++ b/lib.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const split = require('split2')
-const { Client } = require('@elastic/elasticsearch')
+const { Client: DefaultClient } = require('@elastic/elasticsearch')
 
 function initializeBulkHandler (opts, client, splitter) {
   const esVersion = Number(opts.esVersion || opts['es-version']) || 7
@@ -58,7 +58,7 @@ function initializeBulkHandler (opts, client, splitter) {
   }
 }
 
-function pinoElasticSearch (opts = {}) {
+function pinoElasticSearch (opts = {}, { Client = DefaultClient } = {}) {
   if (opts['flush-bytes']) {
     process.emitWarning('The "flush-bytes" option has been deprecated, use "flushBytes" instead')
   }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "pino-elasticsearch": "./cli.js"
   },
   "scripts": {
-    "test": "standard && tsd && tap test/*.test.js -j 1 --disable-coverage --timeout 120"
+    "lint": "eslint .",
+    "test": "tsd && borp 'test/*.test.js' --timeout 60000 --coverage"
   },
-  "pre-commit": "test",
   "keywords": [
     "pino",
     "log",
@@ -24,18 +24,18 @@
   "license": "MIT",
   "devDependencies": {
     "@elastic/ecs-pino-format": "^1.5.0",
-    "@types/node": "^25.0.2",
+    "@types/node": "^25.5.2",
+    "eslint": "^9.39.4",
+    "neostandard": "^0.13.0",
     "pino": "^10.0.0",
-    "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
-    "standard": "^17.1.0",
-    "tap": "^18.7.2",
     "tsd": "^0.33.0"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^8.13.1",
+    "@elastic/elasticsearch": "^8.19.1",
+    "borp": "^1.0.0",
     "minimist": "^1.2.8",
-    "pump": "^3.0.0",
+    "pump": "^3.0.4",
     "split2": "^4.2.0"
   },
   "repository": {

--- a/test-d/lib.test-d.ts
+++ b/test-d/lib.test-d.ts
@@ -1,10 +1,10 @@
-import { expectType, expectDeprecated, expectNotDeprecated, expectDocCommentIncludes } from 'tsd'
-import pinoElasticSearch, { DestinationStream, Options } from '../';
+import { expectType, expectDeprecated, expectNotDeprecated } from 'tsd'
+import pinoElasticSearch, { DestinationStream, Options } from '../'
 
-const options = {} as Options;
+const options = {} as Options
 
 expectType<DestinationStream>(pinoElasticSearch())
-expectType<DestinationStream>(pinoElasticSearch(options));
+expectType<DestinationStream>(pinoElasticSearch(options))
 
 expectDeprecated(options['flush-bytes'])
 expectNotDeprecated(options.flushBytes)

--- a/test/acceptance.test.js
+++ b/test/acceptance.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const { once } = require('events')
+const test = require('node:test')
+const { once } = require('node:events')
 const { pino } = require('pino')
-const elastic = require('../')
-const { teardown, beforeEach, test } = require('tap')
 const { Client } = require('@elastic/elasticsearch')
 const ecsFormat = require('@elastic/ecs-pino-format')
+const elastic = require('../')
 
 const index = 'pinotest'
 const streamIndex = 'logs-pino-test'
@@ -41,8 +41,8 @@ async function esWaitCluster () {
   }
 }
 
-teardown(() => {
-  client.close()
+test.after(async () => {
+  await client.close()
 })
 
 let esVersion = 7
@@ -51,14 +51,16 @@ let esMinor = 15
 const supportsDatastreams =
   () => esVersion > 7 || (esVersion === 7 && esMinor >= 9)
 
-beforeEach(async () => {
+test.beforeEach(async () => {
   if (!await esIsRunning()) {
     await esWaitCluster()
   }
 
   const { version } = await client.info()
+
   esVersion = Number(version.number.split('.')[0])
   esMinor = Number(version.number.split('.')[1])
+
   await client.indices.delete({ index }, { ignore: [404] })
   await client.indices.create({ index })
 
@@ -79,7 +81,9 @@ test('store a log line', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 1)
+
+  t.assert.equal(stats.total, 1)
+
   const documents = await client.helpers.search({
     index,
     type: esVersion >= 7 ? undefined : type,
@@ -87,7 +91,8 @@ test('store a log line', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
-  t.equal(documents[0].msg, 'hello world')
+
+  t.assert.equal(documents[0].msg, 'hello world')
 })
 
 test('Ignores a boolean line even though it is JSON-parsable', { timeout }, (t) => {
@@ -96,8 +101,8 @@ test('Ignores a boolean line even though it is JSON-parsable', { timeout }, (t) 
   const instance = elastic({ index, type, node, auth })
 
   instance.on('unknown', (obj, body) => {
-    t.equal(obj, 'true', 'Object is parsed')
-    t.equal(body, 'Boolean value ignored', 'Message is emitted')
+    t.assert.equal(obj, 'true', 'Object is parsed')
+    t.assert.equal(body, 'Boolean value ignored', 'Message is emitted')
   })
 
   instance.write('true\n')
@@ -109,8 +114,8 @@ test('Ignores "null" being parsed as json', { timeout }, (t) => {
   const instance = elastic({ index, type, node, auth })
 
   instance.on('unknown', (obj, body) => {
-    t.equal(obj, 'null', 'Object is parsed')
-    t.equal(body, 'Null value ignored', 'Message is emitted')
+    t.assert.equal(obj, 'null', 'Object is parsed')
+    t.assert.equal(body, 'Null value ignored', 'Message is emitted')
   })
 
   instance.write('null\n')
@@ -122,7 +127,7 @@ test('Can process number being parsed as json', { timeout }, (t) => {
   const instance = elastic({ index, type, node, auth })
 
   instance.on('unknown', (obj, body) => {
-    t.error(obj, body)
+    t.assert.fail(obj, body)
   })
 
   instance.write('12\n')
@@ -145,7 +150,9 @@ test('store an deeply nested log line', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 1)
+
+  t.assert.equal(stats.total, 1)
+
   const documents = await client.helpers.search({
     index,
     type: esVersion >= 7 ? undefined : type,
@@ -153,7 +160,8 @@ test('store an deeply nested log line', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
-  t.equal(documents[0].deeply.nested.hello, 'world', 'obj gets linearized')
+
+  t.assert.equal(documents[0].deeply.nested.hello, 'world', 'obj gets linearized')
 })
 
 test('store lines in bulk', { timeout }, async (t) => {
@@ -171,7 +179,9 @@ test('store lines in bulk', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 5)
+
+  t.assert.equal(stats.total, 5)
+
   const documents = await client.helpers.search({
     index,
     type: esVersion >= 7 ? undefined : type,
@@ -179,13 +189,15 @@ test('store lines in bulk', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
+
   for (const doc of documents) {
-    t.equal(doc.msg, 'hello world')
+    t.assert.equal(doc.msg, 'hello world')
   }
 })
 
 test('replaces date in index', { timeout }, async (t) => {
   t.plan(2)
+
   const index = 'pinotest-%{DATE}'
 
   const instance = elastic({ index, type, node, esVersion, auth })
@@ -200,7 +212,9 @@ test('replaces date in index', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 1)
+
+  t.assert.equal(stats.total, 1)
+
   const documents = await client.helpers.search({
     index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
     type: esVersion >= 7 ? undefined : type,
@@ -208,7 +222,8 @@ test('replaces date in index', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
-  t.equal(documents[0].msg, 'hello world')
+
+  t.assert.equal(documents[0].msg, 'hello world')
 })
 
 test('replaces date in index during bulk insert', { timeout }, async (t) => {
@@ -232,7 +247,9 @@ test('replaces date in index during bulk insert', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 5)
+
+  t.assert.equal(stats.total, 5)
+
   const documents = await client.helpers.search({
     index: index.replace('%{DATE}', new Date().toISOString().substring(0, 10)),
     type: esVersion >= 7 ? undefined : type,
@@ -240,8 +257,9 @@ test('replaces date in index during bulk insert', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
+
   for (const doc of documents) {
-    t.equal(doc.msg, 'hello world')
+    t.assert.equal(doc.msg, 'hello world')
   }
 })
 
@@ -256,7 +274,9 @@ test('Use ecs format', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 1)
+
+  t.assert.equal(stats.total, 1)
+
   const documents = await client.helpers.search({
     index,
     type: esVersion >= 7 ? undefined : type,
@@ -264,7 +284,8 @@ test('Use ecs format', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
-  t.type(documents[0]['@timestamp'], 'string')
+
+  t.assert.equal(typeof documents[0]['@timestamp'], 'string')
 })
 
 test('dynamic index name', { timeout }, async (t) => {
@@ -272,7 +293,7 @@ test('dynamic index name', { timeout }, async (t) => {
 
   let indexNameGenerated
   const index = function (time) {
-    t.match(time, new Date().toISOString().substring(0, 10))
+    t.assert.equal(time.startsWith(new Date().toISOString().substring(0, 10)), true)
     indexNameGenerated = `dynamic-index-${process.pid}`
     return indexNameGenerated
   }
@@ -285,7 +306,7 @@ test('dynamic index name', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 1)
+  t.assert.equal(stats.total, 1)
   const documents = await client.helpers.search({
     index: indexNameGenerated,
     type: esVersion >= 7 ? undefined : type,
@@ -293,7 +314,7 @@ test('dynamic index name', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
-  t.equal(documents[0].msg, 'hello world')
+  t.assert.equal(documents[0].msg, 'hello world')
 })
 
 test('dynamic index name during bulk insert', { timeout }, async (t) => {
@@ -301,7 +322,7 @@ test('dynamic index name during bulk insert', { timeout }, async (t) => {
 
   let indexNameGenerated
   const index = function (time) {
-    t.match(time, new Date().toISOString().substring(0, 10))
+    t.assert.equal(time.startsWith(new Date().toISOString().substring(0, 10)), true)
     indexNameGenerated = `dynamic-index-${process.pid + 1}`
     return indexNameGenerated
   }
@@ -318,7 +339,9 @@ test('dynamic index name during bulk insert', { timeout }, async (t) => {
   setImmediate(() => instance.end())
 
   const [stats] = await once(instance, 'insert')
-  t.equal(stats.total, 5)
+
+  t.assert.equal(stats.total, 5)
+
   const documents = await client.helpers.search({
     index: indexNameGenerated,
     type: esVersion >= 7 ? undefined : type,
@@ -326,20 +349,19 @@ test('dynamic index name during bulk insert', { timeout }, async (t) => {
       query: { match_all: {} }
     }
   })
+
   for (const doc of documents) {
-    t.equal(doc.msg, 'hello world')
+    t.assert.equal(doc.msg, 'hello world')
   }
 })
 
 test('handle datastreams during bulk insert', { timeout }, async (t) => {
   if (supportsDatastreams()) {
-    // Arrange
     t.plan(6)
 
     const instance = elastic({ index: streamIndex, type, node, esVersion, opType: 'create', auth })
     const log = pino(instance)
 
-    // Act
     const logEntries = [
       { time: '2021-09-01T01:01:01.732Z' },
       { time: '2021-09-01T01:01:02.400Z' },
@@ -352,9 +374,9 @@ test('handle datastreams during bulk insert', { timeout }, async (t) => {
 
     setImmediate(() => instance.end())
 
-    // Assert
     const [stats] = await once(instance, 'insert')
-    t.equal(stats.successful, 5)
+
+    t.assert.equal(stats.successful, 5)
 
     const documents = await client.helpers.search({
       index: streamIndex,
@@ -365,10 +387,9 @@ test('handle datastreams during bulk insert', { timeout }, async (t) => {
     })
 
     for (let i = 0; i < documents.length; i++) {
-      t.equal(documents[i]['@timestamp'], logEntries[i].time)
+      t.assert.equal(documents[i]['@timestamp'], logEntries[i].time)
     }
   } else {
-    t.comment('The current elasticsearch version does not support datastreams yet!')
+    t.diagnostic('The current elasticsearch version does not support datastreams yet!')
   }
-  t.end()
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,12 +1,15 @@
 'use strict'
-const test = require('tap').test
+
+const test = require('node:test')
 const proxyquire = require('proxyquire')
 
 test('CLI: arg node should passed to client constructor', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, { node: 'https://custom-node-url:9999' })
+      t.assert.deepEqual(opts, { node: 'https://custom-node-url:9999' })
       return {
         on: () => { }
       }
@@ -17,10 +20,12 @@ test('CLI: arg node should passed to client constructor', async (t) => {
 })
 
 test('CLI: arg rejectUnauthorized, if set to \'true\', should passed as true (bool) to client constructor', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: true
       })
@@ -37,10 +42,12 @@ test('CLI: arg rejectUnauthorized, if set to \'true\', should passed as true (bo
 })
 
 test('CLI: arg rejectUnauthorized, if set to \'false\', should passed as false (bool) to client constructor', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: false
       })
@@ -57,10 +64,12 @@ test('CLI: arg rejectUnauthorized, if set to \'false\', should passed as false (
 })
 
 test('CLI: arg rejectUnauthorized, if set to anything instead of true or false, should passed as true (bool) to client constructor', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         rejectUnauthorized: true
       })
@@ -77,10 +86,12 @@ test('CLI: arg rejectUnauthorized, if set to anything instead of true or false, 
 })
 
 test('CLI: if arg.read-config is set, should read the config file and passed the value (only allowed values)', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         index: 'custom-index',
         node: 'https://127.0.0.1:9200',
         rejectUnauthorized: false,
@@ -107,10 +118,12 @@ test('CLI: if arg.read-config is set, should read the config file and passed the
 })
 
 test('CLI: arg opType should be passed to client constructor', async (t) => {
+  t.plan(1)
+
   const cli = proxyquire('../cli.js', {
     pump: () => { },
     './lib.js': (opts) => {
-      t.same(opts, {
+      t.assert.deepEqual(opts, {
         node: 'https://custom-node-url:9999',
         opType: 'create'
       })

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
+const { test } = require('node:test')
 const pino = require('pino')
-const proxyquire = require('proxyquire')
-const test = require('tap').test
-const fix = require('./fixtures')
 const EcsFormat = require('@elastic/ecs-pino-format')
+const elastic = require('../')
+const fix = require('./fixtures')
 
 const matchISOString = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
 const options = {
@@ -19,40 +19,48 @@ const dsOptions = {
 }
 
 test('make sure date format is valid', (t) => {
-  t.type(fix.datetime.object, 'string')
-  t.equal(fix.datetime.object, fix.datetime.string)
-  t.end()
+  t.assert.equal(typeof fix.datetime.object, 'string')
+  t.assert.equal(fix.datetime.object, fix.datetime.string)
 })
 
-test('make sure log is a valid json', (t) => {
+test('make sure log is a valid json', (t, done) => {
   t.plan(4)
+
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
-        t.ok(chunk, true)
-        t.type(chunk.time, 'string')
-        t.match(chunk.time, matchISOString)
+        t.assert.ok(chunk)
+        t.assert.equal(typeof chunk.time, 'string')
+        t.assert.match(chunk.time, matchISOString)
       }
+
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(options)
+
+  const instance = elastic(options, { Client })
   const log = pino(instance)
+
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('date can be a number', (t) => {
+test('date can be a number', (t, done) => {
   t.plan(1)
-  const Client = function (config) {}
+
+  const Client = function (config) { }
+
   Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
 
   const threeDaysInMillis = 3 * 24 * 60 * 60 * 1000
   const time = new Date(Date.now() - threeDaysInMillis)
@@ -60,155 +68,180 @@ test('date can be a number', (t) => {
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
-        t.equal(chunk.time, time.toISOString())
+        t.assert.equal(chunk.time, time.toISOString())
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(options)
+  const instance = elastic(options, { Client })
   const log = pino(instance)
-  log.info({
-    time: time.getTime()
-  })
+
+  log.info({ time: time.getTime() })
+
+  setImmediate(() => instance.end())
 })
 
-test('Uses the type parameter only with ES < 7 / 1', (t) => {
+test('Uses the type parameter only with ES < 7 / 1', (t, done) => {
   t.plan(2)
 
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
-  Client.prototype.diagnostic = { on: () => {} }
 
+  Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
         const action = opts.onDocument(chunk)
-        t.equal(action.index._type, 'log')
+
+        t.assert.equal(action.index._type, 'log')
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 6 }))
+  const instance = elastic({ ...options, esVersion: 6 }, { Client })
   const log = pino(instance)
+
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('Uses the type parameter only with ES < 7 / 1, even with the deprecated `esVersion` option', (t) => {
+test('Uses the type parameter only with ES < 7 / 1, even with the deprecated `esVersion` option', (t, done) => {
   t.plan(2)
 
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
-  Client.prototype.diagnostic = { on: () => {} }
 
+  Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
         const action = opts.onDocument(chunk)
-        t.equal(action.index._type, 'log')
+
+        t.assert.equal(action.index._type, 'log')
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 6 }))
+  const instance = elastic({ ...options, esVersion: 6 }, { Client })
   const log = pino(instance)
+
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('Uses the type parameter only with ES < 7 / 2', (t) => {
+test('Uses the type parameter only with ES < 7 / 2', (t, done) => {
   t.plan(2)
 
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
         const action = opts.onDocument(chunk)
-        t.equal(action.index._type, undefined)
+
+        t.assert.equal(action.index._type, undefined)
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 7 }))
+  const instance = elastic({ ...options, esVersion: 7 }, { Client })
   const log = pino(instance)
+
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('Uses the type parameter only with ES < 7 / 2, even with the deprecate `esVersion` option', (t) => {
+test('Uses the type parameter only with ES < 7 / 2, even with the deprecate `esVersion` option', (t, done) => {
   t.plan(2)
+
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
         const action = opts.onDocument(chunk)
-        t.equal(action.index._type, undefined)
+
+        t.assert.equal(action.index._type, undefined)
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { esVersion: 7 }))
+  const instance = elastic({ ...options, esVersion: 7 }, { Client })
   const log = pino(instance)
+
   const prettyLog = `some logs goes here.
   another log...`
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('ecs format', (t) => {
+test('ecs format', (t, done) => {
   t.plan(5)
+
+  const prettyLog = 'some logs goes here.\n  another log...'
   const Client = function (config) {
-    t.equal(config.node, options.node)
+    t.assert.equal(config.node, options.node)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
       for await (const chunk of opts.datasource) {
-        t.ok(chunk, true)
-        t.type(chunk['@timestamp'], 'string')
-        t.equal(chunk.message, prettyLog)
-        t.match(chunk['@timestamp'], matchISOString)
+        t.assert.ok(chunk)
+        t.assert.equal(typeof chunk['@timestamp'], 'string')
+        t.assert.equal(chunk.message, prettyLog)
+        t.assert.match(chunk['@timestamp'], matchISOString)
       }
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  const instance = elastic(Object.assign(options, { ecs: true }))
+  const instance = elastic({ ...options, ecs: true }, { Client })
   const ecsFormat = EcsFormat()
   const log = pino({ ...ecsFormat }, instance)
-  const prettyLog = `some logs goes here.
-  another log...`
+
   log.info(['info'], prettyLog)
+
+  setImmediate(() => instance.end())
 })
 
-test('auth and cloud parameters are properly passed to client', (t) => {
+test('auth and cloud parameters are properly passed to client', (t, done) => {
+  t.plan(3)
+
   const opts = {
     ...options,
     auth: {
@@ -220,23 +253,24 @@ test('auth and cloud parameters are properly passed to client', (t) => {
     }
   }
 
-  t.plan(3)
   const Client = function (config) {
-    t.equal(config.node, opts.node)
-    t.equal(config.auth, opts.auth)
-    t.equal(config.cloud, opts.cloud)
+    t.assert.equal(config.node, opts.node)
+    t.assert.equal(config.auth, opts.auth)
+    t.assert.equal(config.cloud, opts.cloud)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {}
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  elastic(opts)
+  Client.prototype.connectionPool = { resurrect: () => {} }
+  Client.prototype.helpers = { async bulk () { } }
+
+  elastic(opts, { Client })
+
+  done()
 })
 
-test('apiKey is passed through auth param properly to client', (t) => {
+test('apiKey is passed through auth param properly to client', (t, done) => {
+  t.plan(2)
+
   const opts = {
     ...options,
     auth: {
@@ -244,186 +278,207 @@ test('apiKey is passed through auth param properly to client', (t) => {
     }
   }
 
-  t.plan(2)
   const Client = function (config) {
-    t.equal(config.node, opts.node)
-    t.equal(config.auth, opts.auth)
+    t.assert.equal(config.node, opts.node)
+    t.assert.equal(config.auth, opts.auth)
   }
+
   Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = {
-    async bulk (opts) {}
-  }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-  elastic(opts)
+  Client.prototype.connectionPool = { resurrect: () => {} }
+  Client.prototype.helpers = { async bulk () { } }
+
+  elastic(opts, { Client })
+
+  done()
 })
 
-test('make sure `flushInterval` is passed to bulk request', (t) => {
-  t.plan(1)
+test('make sure `flushInterval` is passed to bulk request', (t, done) => {
+  t.plan(2)
 
-  const Client = function (config) {}
+  const Client = function (config) { }
+
   Client.prototype.diagnostic = { on: () => {} }
-
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      t.equal(opts.flushInterval, 12345)
+      for await (const chunk of opts.datasource) {
+        t.assert.equal(opts.flushInterval, 12345)
+        t.assert.ok(chunk)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  options.flushInterval = 12345
-  const instance = elastic(options)
+  const instance = elastic({ ...options, flushInterval: 12345 }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure deprecated `flushInterval` is passed to bulk request', (t) => {
-  t.plan(1)
+test('make sure deprecated `flush-interval` is passed to bulk request', (t, done) => {
+  t.plan(2)
 
   const flushInterval = 12345
+  const Client = function (config) { }
 
-  const Client = function (config) {}
   Client.prototype.diagnostic = { on: () => {} }
-
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      t.equal(opts.flushInterval, flushInterval)
+      for await (const chunk of opts.datasource) {
+        t.assert.equal(opts.flushInterval, flushInterval)
+        t.assert.ok(chunk)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  const instance = elastic({ ...options, flushInterval })
+  const instance = elastic({ ...options, 'flush-interval': flushInterval }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure `flushBytes` is passed to bulk request', (t) => {
-  t.plan(1)
+test('make sure `flushBytes` is passed to bulk request', (t, done) => {
+  t.plan(2)
 
   const flushBytes = true
 
   const Client = function (config) {}
   Client.prototype.diagnostic = { on: () => {} }
-
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      t.equal(opts.flushBytes, flushBytes)
+      for await (const chunk of opts.datasource) {
+        t.assert.equal(opts.flushBytes, flushBytes)
+        t.assert.ok(chunk)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  const instance = elastic({ ...options, flushBytes })
+  const instance = elastic({ ...options, flushBytes }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure deprecated `flush-bytes` is passed to bulk request', (t) => {
-  t.plan(1)
+test('make sure deprecated `flush-bytes` is passed to bulk request', (t, done) => {
+  t.plan(2)
 
   const flushBytes = true
 
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
+  const Client = function (config) { }
 
+  Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      t.equal(opts.flushBytes, flushBytes)
+      for await (const chunk of opts.datasource) {
+        t.assert.equal(opts.flushBytes, flushBytes)
+        t.assert.ok(chunk)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  const instance = elastic({ ...options, 'flush-bytes': flushBytes })
+  const instance = elastic({ ...options, 'flush-bytes': flushBytes }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure `opType` is passed to bulk onDocument request', (t) => {
+test('make sure `opType` is passed to bulk onDocument request', (t, done) => {
   t.plan(2)
 
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
+  const Client = function (config) { }
 
+  Client.prototype.diagnostic = { on: () => { } }
+  Client.prototype.connectionPool = { resurrect: () => { } }
   Client.prototype.helpers = {
     async bulk (opts) {
-      const result = opts.onDocument({})
-      t.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
-      t.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
-      t.end()
+      for await (const chunk of opts.datasource) {
+        const result = opts.onDocument(chunk)
+        t.assert.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
+        t.assert.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  const instance = elastic(dsOptions)
+  const instance = elastic(dsOptions, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure deprecated `op_type` is passed to bulk onDocument request', (t) => {
+test('make sure deprecated `op_type` is passed to bulk onDocument request', (t, done) => {
   t.plan(2)
 
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
+  const Client = function (config) { }
 
+  Client.prototype.diagnostic = { on: () => {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      const result = opts.onDocument({})
-      t.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
-      t.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
-      t.end()
+      for await (const chunk of opts.datasource) {
+        const result = opts.onDocument(chunk)
+        t.assert.equal(result.index._index, dsOptions.index, `_index should be correctly set to \`${dsOptions.index}\``)
+        t.assert.equal(result.index.op_type, dsOptions.opType, `\`op_type\` should be set to \`${dsOptions.opType}\``)
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
   const { opType, ...rest } = dsOptions
-
-  const instance = elastic({ ...rest, op_type: opType })
+  const instance = elastic({ ...rest, op_type: opType }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('make sure `@timestamp` is correctly set when `opType` is `create`', (t) => {
+test('make sure `@timestamp` is correctly set when `opType` is `create`', (t, done) => {
   t.plan(1)
 
-  const document = {
-    time: '2021-09-01T01:01:01.038Z'
-  }
   const Client = function (config) {}
   Client.prototype.diagnostic = { on: () => {} }
-
+  Client.prototype.connectionPool = { resurrect: () => {} }
   Client.prototype.helpers = {
     async bulk (opts) {
-      opts.onDocument(document)
-      t.equal(document['@timestamp'], '2021-09-01T01:01:01.038Z', 'Document @timestamp does not equal the provided timestamp')
-      t.end()
+      for await (const chunk of opts.datasource) {
+        opts.onDocument(chunk)
+        t.assert.equal(chunk['@timestamp'], chunk.time, 'Document @timestamp does not equal the provided timestamp')
+      }
+      done()
     }
   }
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
 
-  const instance = elastic(dsOptions)
+  const instance = elastic(dsOptions, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  setImmediate(() => instance.end())
 })
 
-test('resurrect client connection pool when datasource split is destroyed', (t) => {
+test('resurrect client connection pool when datasource split is destroyed', (t, done) => {
   let isResurrected = false
-  const Client = function (config) {}
-  Client.prototype.diagnostic = { on: () => {} }
 
+  const Client = function (config) { }
+
+  Client.prototype.diagnostic = { on: () => {} }
   Client.prototype.helpers = {
     bulk: async function (opts) {
       if (!isResurrected) {
@@ -431,85 +486,80 @@ test('resurrect client connection pool when datasource split is destroyed', (t) 
       }
     }
   }
-
   Client.prototype.connectionPool = {
     resurrect: function () {
       isResurrected = true
-      t.end()
+
+      done()
     }
   }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options })
+  const instance = elastic({ ...options }, { Client })
   const log = pino(instance)
 
-  const prettyLog = 'Example of a log'
-  log.info(['info'], prettyLog)
+  log.info(['info'], 'Example of a log')
 })
 
-test('make sure deprecated `rejectUnauthorized` is passed to client constructor', (t) => {
+test('make sure deprecated `rejectUnauthorized` is passed to client constructor', (t, done) => {
   t.plan(1)
 
   const rejectUnauthorized = true
 
   const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, rejectUnauthorized)
+    t.assert.equal(config.tls.rejectUnauthorized, rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
+  Client.prototype.helpers = { async bulk () { } }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, rejectUnauthorized })
+  const instance = elastic({ ...options, rejectUnauthorized }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  done()
 })
 
-test('make sure `tls.rejectUnauthorized` is passed to client constructor', (t) => {
+test('make sure `tls.rejectUnauthorized` is passed to client constructor', (t, done) => {
   t.plan(1)
 
   const tls = { rejectUnauthorized: true }
 
   const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
+    t.assert.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
+  Client.prototype.helpers = { async bulk () { } }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, tls })
+  const instance = elastic({ ...options, tls }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  done()
 })
 
-test('make sure `tls.rejectUnauthorized` overrides deprecated `rejectUnauthorized`', (t) => {
+test('make sure `tls.rejectUnauthorized` overrides deprecated `rejectUnauthorized`', (t, done) => {
   t.plan(1)
 
   const rejectUnauthorized = true
   const tls = { rejectUnauthorized: false }
 
   const Client = function (config) {
-    t.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
+    t.assert.equal(config.tls.rejectUnauthorized, tls.rejectUnauthorized)
   }
 
   Client.prototype.diagnostic = { on: () => {} }
-  Client.prototype.helpers = { async bulk () {} }
+  Client.prototype.connectionPool = { resurrect: () => {} }
+  Client.prototype.helpers = { async bulk () { } }
 
-  const elastic = proxyquire('../', {
-    '@elastic/elasticsearch': { Client }
-  })
-
-  const instance = elastic({ ...options, rejectUnauthorized, tls })
+  const instance = elastic({ ...options, rejectUnauthorized, tls }, { Client })
   const log = pino(instance)
+
   log.info(['info'], 'abc')
+
+  done()
 })


### PR DESCRIPTION
Supersedes https://github.com/pinojs/pino-elasticsearch/pull/213

### Changes:
- Drop Node.js 18 from `ci.yml`
- Use `node:test` and `node:assert/strict` instead of `tap`
- Update dependencies
- Migrate from `standard` to `neostandard`
- Remove `pre-commit`
- Fix CI